### PR TITLE
Update docker-compose.yml

### DIFF
--- a/launch/docker/docker-compose.yml
+++ b/launch/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   astron:
+    platform: linux/amd64
     build:
-      platform: linux/amd64
       context: ../..
       dockerfile: launch/docker/astron.dockerfile
     ports:


### PR DESCRIPTION
Fixed platform line. Before it was producing the following error on macOS:

`$ docker compose up`
`validating /path/to/toontown-archipelago/launch/docker/docker-compose.yml: services.astron.build Additional property platform is not allowed`

After fixing this line, I was able to get a server running.