### PR TITLE
Basic trolley skip button

### DIFF
--- a/astron/dclass/ttap.dc
+++ b/astron/dclass/ttap.dc
@@ -1677,6 +1677,7 @@ dclass DistributedMinigame : DistributedObject {
   setAvatarReady() airecv clsend;
   setAvatarExited() airecv clsend;
   requestExit() airecv clsend;
+  requestSkip() airecv clsend;
   setGameReady() broadcast;
   setGameStart(int16) broadcast;
   setGameExit() broadcast;

--- a/toontown/minigame/DistributedMinigame.py
+++ b/toontown/minigame/DistributedMinigame.py
@@ -40,6 +40,7 @@ class DistributedMinigame(DistributedObject.DistributedObject):
         hoodMinigameState.addChild(self.frameworkFSM)
         self.rulesDoneEvent = 'rulesDone'
         self.acceptOnce('minigameAbort', self.d_requestExit)
+        self.accept('minigameSkip', self.d_requestSkip)
         base.curMinigame = self
         self.modelCount = 500
         self.cleanupActions = []
@@ -315,6 +316,9 @@ class DistributedMinigame(DistributedObject.DistributedObject):
     def d_requestExit(self):
         self.notify.debug('BASE: Sending requestExit')
         self.sendUpdate('requestExit', [])
+
+    def d_requestSkip(self):
+        self.sendUpdate('requestSkip')
 
     def enterFrameworkInit(self):
         self.notify.debug('BASE: enterFrameworkInit')

--- a/toontown/minigame/DistributedMinigameAI.py
+++ b/toontown/minigame/DistributedMinigameAI.py
@@ -44,6 +44,7 @@ class DistributedMinigameAI(DistributedObjectAI.DistributedObjectAI):
 
         self.frameworkFSM.enterInitialState()
         self.avIdList = []
+        self.toonsSkipped = []
         self.stateDict = {}
         self.scoreDict = {}
         self.difficultyOverride = None
@@ -394,6 +395,27 @@ class DistributedMinigameAI(DistributedObjectAI.DistributedObjectAI):
     def requestExit(self):
         self.notify.debug('BASE: requestExit: client has requested the game to end')
         self.setGameAbort()
+
+    def checkSkip(self):
+        self.notify.info("Checking skip")
+        if len(self.toonsSkipped) >= 1:
+            # exit minigame
+            self.notify.info('Skipping minigame')
+            self.requestExit()
+        # else:
+        #     # tell the client the amount of toons skipped
+        #     self.notify.info('Sending client skip amount')
+        #     self.sendUpdate('setSkipAmount', [len(self.toonsSkipped)])
+        return
+    
+    def requestSkip(self):
+        toon = self.air.getAvatarIdFromSender()
+        if (toon not in self.avIdList) or (toon in self.toonsSkipped):
+            self.notify.warning('Unable to request skip')
+            return
+        self.toonsSkipped.append(toon)
+        self.notify.info('toons Skipped appended')
+        self.checkSkip()
 
     def local2GameTime(self, timestamp):
         return timestamp - self.gameStartTime

--- a/toontown/minigame/DistributedTargetGame.py
+++ b/toontown/minigame/DistributedTargetGame.py
@@ -526,6 +526,7 @@ class DistributedTargetGame(DistributedMinigame):
         self.environModel.removeNode()
         del self.environModel
         self.fogOver.delete()
+        self.umbrella.hide()
         self.umbrella.removeNode()
         del self.umbrella
         for umbrella in self.remoteUmbrellas:

--- a/toontown/minigame/MinigameRulesPanel.py
+++ b/toontown/minigame/MinigameRulesPanel.py
@@ -44,7 +44,7 @@ class MinigameRulesPanel(StateData.StateData):
 
     def enter(self):
         self.frame.show()
-        # self.timer.countdown(self.TIMEOUT, self.playCallback)
+        self.timer.countdown(self.TIMEOUT, self.playCallback)
         self.accept('enter', self.playCallback)
 
     def exit(self):

--- a/toontown/minigame/MinigameRulesPanel.py
+++ b/toontown/minigame/MinigameRulesPanel.py
@@ -22,6 +22,7 @@ class MinigameRulesPanel(StateData.StateData):
         self.gameTitleText = DirectLabel(parent=self.frame, text=self.gameTitle, scale=TTLocalizer.MRPgameTitleText, text_align=TextNode.ACenter, text_font=getSignFont(), text_fg=(1.0, 0.33, 0.33, 1.0), pos=TTLocalizer.MRgameTitleTextPos, relief=None)
         self.instructionsText = DirectLabel(parent=self.frame, text=self.instructions, scale=TTLocalizer.MRPinstructionsText, text_align=TextNode.ACenter, text_wordwrap=TTLocalizer.MRPinstructionsTextWordwrap, pos=TTLocalizer.MRPinstructionsTextPos, relief=None)
         self.playButton = DirectButton(parent=self.frame, relief=None, image=(buttonGui.find('**/InventoryButtonUp'), buttonGui.find('**/InventoryButtonDown'), buttonGui.find('**/InventoryButtonRollover')), image_color=Vec4(0, 0.9, 0.1, 1), text=TTLocalizer.MinigameRulesPanelPlay, text_fg=(1, 1, 1, 1), text_pos=(0, -0.02, 0), text_scale=TTLocalizer.MRPplayButton, pos=(1.0025, 0, -0.203), scale=1.05, command=self.playCallback)
+        self.skipButton = DirectButton(parent=self.frame, relief=None, image=(buttonGui.find('**/InventoryButtonUp'), buttonGui.find('**/InventoryButtonDown'), buttonGui.find('**/InventoryButtonRollover')), image_color=Vec4(0.9, 0.3, 0.3, 1), text=TTLocalizer.MinigameRulesPanelSkip, text_fg=(1, 1, 1, 1), text_pos=(0, -0.02, 0), text_scale=TTLocalizer.MRPskipButton, pos=(1.0025, 0, 0.253), scale=0.95, command=self.skipCallback)
         minigameGui.removeNode()
         buttonGui.removeNode()
         self.timer = ToontownTimer.ToontownTimer()
@@ -37,6 +38,7 @@ class MinigameRulesPanel(StateData.StateData):
         del self.gameTitleText
         del self.instructionsText
         self.playButton.destroy()
+        self.skipButton.destroy()
         del self.playButton
         del self.timer
 
@@ -52,3 +54,6 @@ class MinigameRulesPanel(StateData.StateData):
 
     def playCallback(self):
         messenger.send(self.doneEvent)
+
+    def skipCallback(self):
+        messenger.send('minigameAbort')

--- a/toontown/minigame/MinigameRulesPanel.py
+++ b/toontown/minigame/MinigameRulesPanel.py
@@ -22,7 +22,7 @@ class MinigameRulesPanel(StateData.StateData):
         self.gameTitleText = DirectLabel(parent=self.frame, text=self.gameTitle, scale=TTLocalizer.MRPgameTitleText, text_align=TextNode.ACenter, text_font=getSignFont(), text_fg=(1.0, 0.33, 0.33, 1.0), pos=TTLocalizer.MRgameTitleTextPos, relief=None)
         self.instructionsText = DirectLabel(parent=self.frame, text=self.instructions, scale=TTLocalizer.MRPinstructionsText, text_align=TextNode.ACenter, text_wordwrap=TTLocalizer.MRPinstructionsTextWordwrap, pos=TTLocalizer.MRPinstructionsTextPos, relief=None)
         self.playButton = DirectButton(parent=self.frame, relief=None, image=(buttonGui.find('**/InventoryButtonUp'), buttonGui.find('**/InventoryButtonDown'), buttonGui.find('**/InventoryButtonRollover')), image_color=Vec4(0, 0.9, 0.1, 1), text=TTLocalizer.MinigameRulesPanelPlay, text_fg=(1, 1, 1, 1), text_pos=(0, -0.02, 0), text_scale=TTLocalizer.MRPplayButton, pos=(1.0025, 0, -0.203), scale=1.05, command=self.playCallback)
-        self.skipButton = DirectButton(parent=self.frame, relief=None, image=(buttonGui.find('**/InventoryButtonUp'), buttonGui.find('**/InventoryButtonDown'), buttonGui.find('**/InventoryButtonRollover')), image_color=Vec4(0.9, 0.3, 0.3, 1), text=TTLocalizer.MinigameRulesPanelSkip, text_fg=(1, 1, 1, 1), text_pos=(0, -0.02, 0), text_scale=TTLocalizer.MRPskipButton, pos=(1.0025, 0, 0.253), scale=0.95, command=self.skipCallback)
+        self.skipButton = DirectButton(parent=self.frame, relief=None, image=(buttonGui.find('**/InventoryButtonUp'), buttonGui.find('**/InventoryButtonDown'), buttonGui.find('**/InventoryButtonRollover')), image_color=Vec4(0.9, 0.3, 0.3, 1), text=TTLocalizer.MinigameRulesPanelSkip, text_fg=(1, 1, 1, 1), text_pos=(0, -0.02, 0), text_scale=TTLocalizer.MRPskipButton, pos=(0.7, 0, 0.125), scale=0.95, command=self.skipCallback)
         minigameGui.removeNode()
         buttonGui.removeNode()
         self.timer = ToontownTimer.ToontownTimer()
@@ -44,7 +44,7 @@ class MinigameRulesPanel(StateData.StateData):
 
     def enter(self):
         self.frame.show()
-        self.timer.countdown(self.TIMEOUT, self.playCallback)
+        # self.timer.countdown(self.TIMEOUT, self.playCallback)
         self.accept('enter', self.playCallback)
 
     def exit(self):
@@ -56,4 +56,4 @@ class MinigameRulesPanel(StateData.StateData):
         messenger.send(self.doneEvent)
 
     def skipCallback(self):
-        messenger.send('minigameAbort')
+        messenger.send('minigameSkip')

--- a/toontown/toonbase/TTLocalizerEnglish.py
+++ b/toontown/toonbase/TTLocalizerEnglish.py
@@ -5435,6 +5435,7 @@ CogThiefBarrelSaved = '%(num)d Barrel\nSaved!'
 CogThiefNoBarrelsSaved = 'No Barrels\nSaved'
 CogThiefPerfect = 'PERFECT!'
 MinigameRulesPanelPlay = 'PLAY'
+MinigameRulesPanelSkip = 'SKIP'
 GagShopName = "Goofy's Gag Shop"
 GagShopPlayAgain = 'PLAY\nAGAIN'
 GagShopBackToPlayground = 'EXIT BACK TO\nPLAYGROUND'

--- a/toontown/toonbase/TTLocalizerEnglishProperty.py
+++ b/toontown/toonbase/TTLocalizerEnglishProperty.py
@@ -95,6 +95,7 @@ MASPnameText = 0.055
 MRPgameTitleText = 0.11
 MRgameTitleTextPos = (-0.046, 0.2, 0.092)
 MRPplayButton = 0.055
+MRPskipButton = 0.055
 MRPinstructionsText = 0.07
 MRPinstructionsTextWordwrap = 26.5
 MRPinstructionsTextPos = (-0.115, 0.05, 0)


### PR DESCRIPTION
this definitely can be done more elegantly, having the client tell the server to abort the minigame probably isn't the best, although I doubt most people will be on archipelago specifically to play minigames with friends, so it's *probably* fine.

![screenshot_skip_button](https://github.com/user-attachments/assets/60ba7615-7f47-428f-8556-e36e487ea673)


currently trying to figure out how to avoid when skipping toon slingshot, the umbrella stays attached to my toon.