### PR TITLE
Golf: playback rate implementation.

### DIFF
--- a/toontown/golf/DistributedGolfHole.py
+++ b/toontown/golf/DistributedGolfHole.py
@@ -1213,7 +1213,7 @@ class DistributedGolfHole(DistributedPhysicsWorld.DistributedPhysicsWorld, FSM, 
              self.destFrame[0],
              self.destFrameNum,
              newPos))
-        self.playbackFrameNum += 1
+        self.playbackFrameNum = min(self.playbackFrameNum + GolfGlobals.SHOT_PLAYBACK_RATE, lastFrame)
 
     def enterCleanup(self):
         taskMgr.remove('update task')
@@ -1541,7 +1541,7 @@ class DistributedGolfHole(DistributedPhysicsWorld.DistributedPhysicsWorld, FSM, 
             childNodePath.removeNode()
 
         self.flyOverJoint = flyOverJoint
-        self.flyOverInterval = Sequence(Func(base.camera.reparentTo, flyOverJoint), Func(base.camera.clearTransform), Func(self.titleLabel.show), ActorInterval(self.flyOverActor, 'camera'), Func(base.camera.reparentTo, self.ballFollow), Func(base.camera.setPos, self.camPosBallFollow), Func(base.camera.setHpr, self.camHprBallFollow))
+        self.flyOverInterval = Sequence(Func(base.camera.reparentTo, flyOverJoint), Func(base.camera.clearTransform), Func(self.titleLabel.show), ActorInterval(self.flyOverActor, 'camera', playRate=GolfGlobals.INTRO_PLAYBACK_RATE), Func(base.camera.reparentTo, self.ballFollow), Func(base.camera.setPos, self.camPosBallFollow), Func(base.camera.setHpr, self.camHprBallFollow))
         if avId == localAvatar.doId:
             self.flyOverInterval.append(Func(self.setCamera2Ball))
             self.flyOverInterval.append(Func(self.safeRequestToState, 'ChooseTee'))

--- a/toontown/golf/GolfGlobals.py
+++ b/toontown/golf/GolfGlobals.py
@@ -28,6 +28,8 @@ TEE_DURATION = 15
 RANDOM_HOLES = True
 KICKOUT_SWINGS = 2
 TIME_TIE_BREAKER = True
+SHOT_PLAYBACK_RATE = 3
+INTRO_PLAYBACK_RATE = 2
 CourseInfo = {0: {'name': '',
      'numHoles': 3,
      'holeIds': (2,


### PR DESCRIPTION
Much faster golfing, but causes the scoreboard to not stay open for very long.
For shots, this is just frameskipping. this shouldn't affect physics, this is just a visual playback - it gets simulated and recorded somewhere else. Will probably look worse on higher numbers, still looked alright at 5, and 5 is ridiculously fast already. The commit sets it to 3 right now. 
For the intro: it's just adjusting the playrate of an animation.

I added globals for the rates to make it easier to change later, if necessary.

This was requested during our run today when a few of us were BKed and went golfing while waiting.