### PR TITLE
Archipelago: Implement ConnectUpdate packet, Deathlink tag only added when enabled.

### DIFF
--- a/toontown/archipelago/apclient/archipelago_client.py
+++ b/toontown/archipelago/apclient/archipelago_client.py
@@ -279,7 +279,7 @@ class ArchipelagoClient(DirectObject):
         connect_packet.uuid = self.uuid
         connect_packet.version = net_utils.ARCHIPELAGO_CLIENT_VERSION
         connect_packet.items_handling = ConnectPacket.ITEMS_HANDLING_ALL_FLAGS
-        connect_packet.tags = [ConnectPacket.TAG_DEATHLINK]
+        connect_packet.tags = []
         connect_packet.slot_data = True
         self.send_packet(connect_packet)
 

--- a/toontown/archipelago/packets/clientbound/bounced_packet.py
+++ b/toontown/archipelago/packets/clientbound/bounced_packet.py
@@ -66,15 +66,7 @@ class BouncedPacket(ClientBoundPacketBase):
     def handle(self, client):
         self.debug("Handling packet")
 
-        if self.tags is None:
-            return
-
         # Is this a deathlink packet?
-        if ConnectPacket.TAG_DEATHLINK in self.tags:
-            # Is deathlink off?
-            if not client.av.slotData.get("death_link", False):
-                self.debug("Client is not participating in DeathLink. Skip this packet")
-                return
-
+        if isinstance(self.tags, list) and ConnectPacket.TAG_DEATHLINK in self.tags:
             self.handle_deathlink(client)
             return

--- a/toontown/archipelago/packets/clientbound/connected_packet.py
+++ b/toontown/archipelago/packets/clientbound/connected_packet.py
@@ -7,6 +7,8 @@ from apworld.toontown.fish import FishProgression
 from toontown.archipelago.apclient.ap_client_enums import APClientEnums
 from toontown.archipelago.definitions.util import ap_location_name_to_id
 from toontown.archipelago.packets.serverbound.status_update_packet import StatusUpdatePacket
+from toontown.archipelago.packets.serverbound.connect_packet import ConnectPacket
+from toontown.archipelago.packets.serverbound.connect_update_packet import ConnectUpdatePacket
 from toontown.archipelago.util.net_utils import NetworkPlayer, NetworkSlot, ClientStatus, SlotType
 from toontown.archipelago.packets.clientbound.clientbound_packet_base import ClientBoundPacketBase
 from toontown.fishing import FishGlobals
@@ -139,6 +141,12 @@ class ConnectedPacket(ClientBoundPacketBase):
         # Get overflow modifier
         overflowMod = self.slot_data.get('overflow_mod', 100)
         av.b_setOverflowMod(overflowMod)
+
+        # Update Deathlink Tag.
+        if self.slot_data.get('deathlink', False):
+            packet = ConnectUpdatePacket()
+            packet.tags = [ConnectPacket.TAG_DEATHLINK]
+            av.archipelago_session.client.send_packet(packet)
 
     def handle(self, client):
         self.debug(f"Successfully connected to the Archipelago server as {self.get_slot_info(self.slot).name}"

--- a/toontown/archipelago/packets/packet_registry.py
+++ b/toontown/archipelago/packets/packet_registry.py
@@ -12,6 +12,7 @@ from toontown.archipelago.packets.clientbound.room_update_packet import RoomUpda
 from toontown.archipelago.packets.clientbound.set_reply_packet import SetReplyPacket
 from toontown.archipelago.packets.serverbound.bounce_packet import BouncePacket
 from toontown.archipelago.packets.serverbound.connect_packet import ConnectPacket
+from toontown.archipelago.packets.serverbound.connect_update_packet import ConnectUpdatePacket
 from toontown.archipelago.packets.serverbound.get_data_package_packet import GetDataPackagePacket
 from toontown.archipelago.packets.serverbound.get_packet import GetPacket
 from toontown.archipelago.packets.serverbound.location_checks_packet import LocationChecksPacket
@@ -40,6 +41,7 @@ PACKET_CMD_TO_CLASS = {
 
     # Client -> Server packets
     'Connect': ConnectPacket,
+    'ConnectUpdate': ConnectUpdatePacket,
     'Sync': SyncPacket,
     'LocationChecks': LocationChecksPacket,
     'LocationScouts': LocationScoutsPacket,

--- a/toontown/archipelago/packets/serverbound/connect_update_packet.py
+++ b/toontown/archipelago/packets/serverbound/connect_update_packet.py
@@ -1,0 +1,31 @@
+from typing import Any, Dict, List
+
+from toontown.archipelago.packets.serverbound.serverbound_packet_base import ServerBoundPacketBase
+
+
+# Sent by the client to initiate a connection to an Archipelago game session.
+class ConnectUpdatePacket(ServerBoundPacketBase):
+    def __init__(self):
+        super().__init__()
+
+        self.cmd = "ConnectUpdate"
+
+        # Flags configuring which items should be sent by the server. Read below for individual flags.
+        self.items_handling: int = None
+        # Denotes special features or capabilities that the sender is capable of. Tags
+        self.tags: List[str] = None
+
+    def build(self) -> Dict[str, Any]:
+        # Return all attributes
+        return {
+            'cmd': self.cmd,
+            'items_handling': self.items_handling,
+            'tags': self.tags
+        }
+
+# Example of using this packet
+
+# connect_update_packet = ConnectPacket()
+# connect_packet.items_handling = ConnectPacket.ITEMS_HANDLING_ALL_FLAGS
+# connect_packet.tags = [ConnectPacket.TAG_DEATHLINK]
+# client.send_packet(connect_packet)


### PR DESCRIPTION
Implements [ConnectUpdate](https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/network%20protocol.md#connectupdate) and now connects without the deathlink tag, followed by adding the tag if the slot has deathlink enabled.