### PR TITLE
Validate room on connect to prevent acidentally resetting toons

### DIFF
--- a/astron/dclass/ttap.dc
+++ b/astron/dclass/ttap.dc
@@ -1181,6 +1181,7 @@ dclass DistributedToon : DistributedPlayer {
   setUUID(string) required airecv db;
 
   setSlotData(AstronDict) required ownrecv broadcast;
+  setLastSeed(string = "") required airecv db;
   setArchipelagoAuto(string, string) ownsend airecv;
   setDeathReason(string) airecv clsend;
   clientDied() airecv clsend;

--- a/toontown/archipelago/packets/clientbound/room_info_packet.py
+++ b/toontown/archipelago/packets/clientbound/room_info_packet.py
@@ -83,5 +83,17 @@ class RoomInfoPacket(ClientBoundPacketBase):
         # Update the toon's hint cost
         client.av.hintCostPercentage = self.hint_cost
 
-        # When we are given this packet, we should attempt to connect this player to the room with their slot
-        client.connect()
+
+        print(self.seed_name)
+        print(type(self.seed_name))
+        # Check if this is the last session we connected to.
+        if client.av.checkLastSeed(self.seed_name):
+            client.av.b_setLastSeed(self.seed_name)
+            # When we are given this packet, we should attempt to connect this player to the room with their slot
+            client.connect()
+        else:
+            client.av.d_sendArchipelagoMessage("[AP Client Thread] Attempting to connect to a new seed!")
+            client.av.d_setSystemMessage(0, "Attempting to connect to a new seed!")
+            client.av.d_sendArchipelagoMessage("[AP Client Thread] Please run `~ap reset` before attepting to connect again!")
+            client.av.d_setSystemMessage(0, "Please run `~ap reset` before attepting to connect again!")
+            client.stop()


### PR DESCRIPTION
* Provide feedback to the user when aborting the connection to prevent a reset.
* store archipelago room info's seed_name in the database


Most people play with the same slot name across multiple rooms, so this is just preventing the user from connecting to the wrong room and resetting the toon without any prompt.

depending on how archipelago handles seed_name in it's implementation, this likely can still cause resets connecting between multiple rooms from the same archipelago seed, but running multiple rooms with identical generation at once isn't a very common thing - so it's probably fine to assume two different rooms with the same seed won't be an unintentional reset if it happens.

ideally, eventually we replace "run `~ap reset`" in the dialog with telling the user to click a reset button somewhere, but for now that's all we have.