### PR TITLE
Gag Training: Add More Options

### DIFF
--- a/apworld/EXAMPLE_TOONTOWN.yaml
+++ b/apworld/EXAMPLE_TOONTOWN.yaml
@@ -133,7 +133,7 @@ Toontown:
   # vanilla: unlocks the gag when you get the exp required.
   # unlock: unlocks the gag immediately, giving you the required exp directly.
   # trained: maxes your experience in the track immediately, effectively disabling exp entirely until overcapped.
-  gag_frame_item_behavior: 'trained'
+  gag_frame_item_behavior: 'vanilla'
 
   ### Task Settings ###
 

--- a/apworld/EXAMPLE_TOONTOWN.yaml
+++ b/apworld/EXAMPLE_TOONTOWN.yaml
@@ -125,7 +125,15 @@ Toontown:
 
   # unlock: When unlocking a new gag, you get its respective check.
   # trained: When earning all available experience for a specific gag level, you get its respective check.
+  # disabled: Does not give checks for gags.
   gag_training_check_behavior: 'trained'
+
+  # Behavior of how gag training frame items are handled.
+
+  # vanilla: unlocks the gag when you get the exp required.
+  # unlock: unlocks the gag immediately, giving you the required exp directly.
+  # trained: maxes your experience in the track immediately, effectively disabling exp entirely until overcapped.
+  gag_frame_item_behavior: 'trained'
 
   ### Task Settings ###
 

--- a/apworld/toontown/__init__.py
+++ b/apworld/toontown/__init__.py
@@ -498,6 +498,10 @@ class ToontownWorld(World):
         if not golf:
             forbidden_location_types.add(ToontownLocationType.GOLF)
 
+        gags = self.options.gag_training_check_behavior.value
+        if gags == ToontownOptions.gag_training_check_behavior.option_disabled:
+            forbidden_location_types.add(ToontownLocationType.GAG_TRAINING)
+
         return forbidden_location_types
 
     def _force_item_placement(self, location: ToontownLocationName, item: ToontownItemName) -> None:

--- a/apworld/toontown/__init__.py
+++ b/apworld/toontown/__init__.py
@@ -12,7 +12,7 @@ from .items import ITEM_DESCRIPTIONS, ITEM_DEFINITIONS, ToontownItemDefinition, 
 from .locations import LOCATION_DESCRIPTIONS, LOCATION_DEFINITIONS, EVENT_DEFINITIONS, ToontownLocationName, \
     ToontownLocationType, ALL_TASK_LOCATIONS_SPLIT, LOCATION_NAME_TO_ID, ToontownLocationDefinition, \
     TREASURE_LOCATION_TYPES, BOSS_LOCATION_TYPES
-from .options import ToontownOptions, TPSanity, StartingTaskOption
+from .options import ToontownOptions, TPSanity, StartingTaskOption, GagTrainingCheckBehavior
 from .regions import REGION_DEFINITIONS, ToontownRegionName
 from .ruledefs import test_location, test_entrance, test_item_location
 from .fish import FishProgression, FishChecks
@@ -409,6 +409,7 @@ class ToontownWorld(World):
             "fish_species_required": self.options.fish_species_required.value,
             "laff_points_required": self.options.laff_points_required.value,
             "gag_training_check_behavior": self.options.gag_training_check_behavior.value,
+            "gag_frame_item_behavior": self.options.gag_frame_item_behavior.value,
             "fish_locations": self.options.fish_locations.value,
             "fish_checks": self.options.fish_checks.value,
             "uber_trap_weight": self.options.uber_trap_weight.value,
@@ -499,7 +500,7 @@ class ToontownWorld(World):
             forbidden_location_types.add(ToontownLocationType.GOLF)
 
         gags = self.options.gag_training_check_behavior.value
-        if gags == ToontownOptions.gag_training_check_behavior.option_disabled:
+        if gags == GagTrainingCheckBehavior.option_disabled:
             forbidden_location_types.add(ToontownLocationType.GAG_TRAINING)
 
         return forbidden_location_types

--- a/apworld/toontown/options.py
+++ b/apworld/toontown/options.py
@@ -235,12 +235,29 @@ class GagTrainingCheckBehavior(Choice):
 
     unlock: When unlocking a new gag, you get its respective check.
     trained: When earning all available experience for a specific gag level, you get its respective check.
+    disabled: Does not give checks for gags. !! Might cause issues generating !!
     """
     option_unlock = 0
     option_trained = 1
+    option_disabled = 2
 
     display_name = "Gag Training Check Behavior"
 
+
+class GagTrainingFrameBehavior(Choice):
+    """
+    Behavior of how gag frame items are handled
+
+    vanilla: unlocks the gag when you get the exp required.
+    unlock: unlocks the gag immediately, giving you the required exp directly.
+    trained: maxes your experience in the track immediately, effectively disabling exp entirely until overcap.
+    """
+
+    option_vanilla = 0
+    option_unlock = 1
+    option_trained = 2
+
+    display_name = "Gag Frame Item Behavior"
 
 class LogicalTasksPerPlayground(Range):
     """
@@ -474,6 +491,7 @@ class ToontownOptions(PerGameCommonOptions):
     treasures_per_location: TreasuresPerLocation
     checks_per_boss: ChecksPerBoss
     gag_training_check_behavior: GagTrainingCheckBehavior
+    gag_frame_item_behavior: GagTrainingFrameBehavior
     logical_tasks_per_playground: LogicalTasksPerPlayground
     starting_task_playground: StartingTaskOption
     logical_maxed_cog_gallery: LogicalMaxedCogGallery

--- a/apworld/toontown/options.py
+++ b/apworld/toontown/options.py
@@ -235,11 +235,12 @@ class GagTrainingCheckBehavior(Choice):
 
     unlock: When unlocking a new gag, you get its respective check.
     trained: When earning all available experience for a specific gag level, you get its respective check.
-    disabled: Does not give checks for gags. !! Might cause issues generating !!
+    disabled: Does not give checks for gags.
     """
     option_unlock = 0
     option_trained = 1
     option_disabled = 2
+    default = 1
 
     display_name = "Gag Training Check Behavior"
 
@@ -250,12 +251,13 @@ class GagTrainingFrameBehavior(Choice):
 
     vanilla: unlocks the gag when you get the exp required.
     unlock: unlocks the gag immediately, giving you the required exp directly.
-    trained: maxes your experience in the track immediately, effectively disabling exp entirely until overcap.
+    trained: maxes your experience in the track immediately, effectively disabling exp entirely until overcapped.
     """
 
     option_vanilla = 0
     option_unlock = 1
     option_trained = 2
+    default = 0
 
     display_name = "Gag Frame Item Behavior"
 

--- a/toontown/archipelago/definitions/rewards.py
+++ b/toontown/archipelago/definitions/rewards.py
@@ -230,12 +230,6 @@ class GagTrainingFrameReward(APReward):
             av.inventory.addItemsWithListMax([(self.track, newLevel-1)])  # Give the new gags!!
             av.b_setInventory(av.inventory.makeNetString())
 
-
-        # Handle the setting for frame behavior.
-        
-        if behaviorMode == 1: # unlock gag when receiving frame
-            
-
 class GagUpgradeReward(APReward):
     TOONUP = 0
     TRAP = 1

--- a/toontown/archipelago/definitions/rewards.py
+++ b/toontown/archipelago/definitions/rewards.py
@@ -193,13 +193,17 @@ class GagTrainingFrameReward(APReward):
         return f'phase_14/maps/gags/{ap_icon}.png'
 
     def apply(self, av: "DistributedToonAI"):
+        
+        # Store option for behavior
+        behaviorMode = av.slotData.get("gag_frame_item_behavior", 0)
 
         # Increment track access level by 1
         oldLevel = av.getTrackAccessLevel(self.track)
         newLevel = oldLevel + 1
 
         # Before we do anything, we need to see if they were capped before this so we can award them gags later
-        wasCapped = av.experience.getExp(self.track) == av.experience.getExperienceCapForTrack(self.track)
+        curExp = av.experience.getExp(self.track)
+        wasCapped = curExp == av.experience.getExperienceCapForTrack(self.track)
         # Edge case, we were not technically capped if we are unlocking the "overflow xp" mechanic
         if newLevel >= 8:
             wasCapped = False
@@ -213,11 +217,24 @@ class GagTrainingFrameReward(APReward):
             av.b_setInventory(av.inventory.makeNetString())
         # Now consider the case where we were maxed previously and want to upgrade by giving 1 xp and giving new gags
         # This will also trigger the new gag check to unlock :3
-        elif wasCapped:
-            av.experience.addExp(track=self.track, amount=1)  # Give them enough xp to learn the gag :)
-            av.b_setExperience(av.experience.getCurrentExperience())
+        elif (wasCapped and behaviorMode == 0) or behaviorMode == 1:
+            toNext = av.experience.getNextExpValue(track=self.track, curSkill=curExp)
+            av.experience.addExp(track=self.track, amount=toNext)  # Give them enough xp to learn the gag :)
+            av.ap_setExperience(av.experience.getCurrentExperience())
             av.inventory.addItemsWithListMax([(self.track, newLevel-1)])  # Give the new gags!!
             av.b_setInventory(av.inventory.makeNetString())
+        # Using an if here because this still should run to max level 1 gags.
+        if behaviorMode == 2 and newLevel < 8: # Train Gag when recieving frame.
+            av.experience.setExp(self.track, av.experience.getExperienceCapForTrack(track=self.track)) # max the gag exp.
+            av.ap_setExperience(av.experience.getCurrentExperience())
+            av.inventory.addItemsWithListMax([(self.track, newLevel-1)])  # Give the new gags!!
+            av.b_setInventory(av.inventory.makeNetString())
+
+
+        # Handle the setting for frame behavior.
+        
+        if behaviorMode == 1: # unlock gag when receiving frame
+            
 
 class GagUpgradeReward(APReward):
     TOONUP = 0

--- a/toontown/toon/DistributedToonAI.py
+++ b/toontown/toon/DistributedToonAI.py
@@ -4760,7 +4760,7 @@ class DistributedToonAI(DistributedPlayerAI.DistributedPlayerAI, DistributedSmoo
     def ap_setExperience(self, experience: list[int]):
         self.b_setExperience(experience)
         for i, track in enumerate(ToontownBattleGlobals.Tracks):
-            self.set_ap_data(track, self.experience.getExp(i), True)
+            self.apply_to_ap_data(track, [("max", self.experience.getExp(i))], True)
 
     def request_default_ap_data(self) -> None:
         # keys currently unused = ["tasks"]


### PR DESCRIPTION
* gag_training_check_behavior: disabled, to disable checks from training.
* gag_frame_item_behavior: sets whether gags are given directly when you get the frame, instead of needing to train them.

Changes function in game and AP is able to generate. 