### PR TITLE
Multiple Win Conditions and WebHost OptionsGroups.

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -31,7 +31,8 @@ class Toggle(Option):
 
 #Used by the APWorld for supporting OptionGroups for display on the website. 
 class OptionGroup():
-    pass
+    def __init__(*args, **kwargs):
+        pass
 
 class ProgressionBalancing(Option):
     pass

--- a/Options.py
+++ b/Options.py
@@ -29,5 +29,12 @@ class Toggle(Option):
     pass
 
 
+#Used by the APWorld for supporting OptionGroups for display on the website. 
+class OptionGroup():
+    pass
 
+class ProgressionBalancing(Option):
+    pass
 
+class Accessibility(Option):
+    pass

--- a/apworld/EXAMPLE_TOONTOWN.yaml
+++ b/apworld/EXAMPLE_TOONTOWN.yaml
@@ -64,27 +64,21 @@ Toontown:
 
   ### Completion Settings ###
 
-  # Determines the condition before being able to talk to Flippy to complete the game.
-  # - cog_bosses (default): Player must defeat a number of cog bosses to complete the game (determined by cog_bosses_required).
-  # - total_tasks: Player must complete a total number of tasks to complete the game (determined by total_tasks_required).
-  # - hood_tasks: Player must complete a number of tasks from each neighborhood to complete the game (determined by hood_tasks_required).
-  # - total_gag_tracks: Player must max a certain amount of gag tracks to complete the game (determined by gag_tracks_required).
-  # - total_fish_species: Player must catch a certain amount of fish species to complete the game (determined by fish_species_required).
-  # - laff_o_lympics: Player must reach a certain amount of laff to complete the game (determined by laff_points_required).
+  # The Following Settings determines the conditions required before being able to talk to Flippy to complete the game.
+  # At least one of these should be enabled, otherwise the game will immediately complete.
+  # - (Default) Player must defeat a number of cog bosses to complete the game (determined by cog_bosses_required).
+  win_condition_cog_bosses: "true"
+  # - Player must complete a total number of tasks to complete the game (determined by total_tasks_required).
+  win_condition_total_tasks: "false"
+  # - Player must complete a number of tasks from each neighborhood to complete the game (determined by hood_tasks_required).
+  win_condition_hood_tasks: "false"
+  # - Player must max a certain amount of gag tracks to complete the game (determined by gag_tracks_required).
+  win_condition_gag_tracks: "false"
+  # - Player must catch a certain amount of fish species to complete the game (determined by fish_species_required).
+  win_condition_fish_species: "false"
+  # - Player must reach a certain amount of laff to complete the game (determined by laff_points_required).
   # - - NOTE: laff_o_lympics replaces ALL laff boost items with only +1 Laff Boosts
-  win_condition: cog_bosses
-
-  # NOTE: This condition should NOT be the same as win_condition
-  # Determines a second condition before being able to talk to Flippy to complete the game.
-  # - none (default): Disables this option and only one condition is needed to complete the run.
-  # - cog_bosses: Player must defeat a number of cog bosses to complete the game (determined by cog_bosses_required).
-  # - total_tasks: Player must complete a total number of tasks to complete the game (determined by total_tasks_required).
-  # - hood_tasks: Player must complete a number of tasks from each neighborhood to complete the game (determined by hood_tasks_required).
-  # - total_gag_tracks: Player must max a certain amount of gag tracks to complete the game (determined by gag_tracks_required).
-  # - total_fish_species: Player must catch a certain amount of fish species to complete the game (determined by fish_species_required).
-  # - laff_o_lympics: Player must reach a certain amount of laff to complete the game (determined by laff_points_required).
-  # - - NOTE: laff_o_lympics replaces ALL laff boost items with only +1 Laff Boosts
-  second_win_condition: none
+  win_condition_laff_o_lympics: "false"
 
   # How many cog bosses must be defeated before being able to talk to Flippy to complete the game.
   # Range: 0 to 4

--- a/apworld/toontown/__init__.py
+++ b/apworld/toontown/__init__.py
@@ -12,7 +12,7 @@ from .items import ITEM_DESCRIPTIONS, ITEM_DEFINITIONS, ToontownItemDefinition, 
 from .locations import LOCATION_DESCRIPTIONS, LOCATION_DEFINITIONS, EVENT_DEFINITIONS, ToontownLocationName, \
     ToontownLocationType, ALL_TASK_LOCATIONS_SPLIT, LOCATION_NAME_TO_ID, ToontownLocationDefinition, \
     TREASURE_LOCATION_TYPES, BOSS_LOCATION_TYPES
-from .options import ToontownOptions, TPSanity, StartingTaskOption, GagTrainingCheckBehavior, FacilityLocking, toontown_option_groups, WinCondition
+from .options import ToontownOptions, TPSanity, StartingTaskOption, GagTrainingCheckBehavior, FacilityLocking, toontown_option_groups
 from .regions import REGION_DEFINITIONS, ToontownRegionName
 from .ruledefs import test_location, test_entrance, test_item_location
 from .fish import FishProgression, FishChecks
@@ -409,7 +409,7 @@ class ToontownWorld(World):
             if location.address and location.item and location.item.code and location.item.player == self.player
         ]
 
-        win_condition = ToontownWinCondition.buildFromOptions(self.options)
+        win_condition = ToontownWinCondition.from_options(self.options)
 
         # TODO: if actually removing tasks becomes implemented,
         #       check if there are still enough tasks to complete

--- a/apworld/toontown/__init__.py
+++ b/apworld/toontown/__init__.py
@@ -6,13 +6,13 @@ import random
 from worlds.generic.Rules import set_rule
 
 from . import regions, consts
-from .consts import ToontownItem, ToontownLocation
+from .consts import ToontownItem, ToontownLocation, ToontownWinCondition
 from .items import ITEM_DESCRIPTIONS, ITEM_DEFINITIONS, ToontownItemDefinition, get_item_def_from_id, ToontownItemName, \
     ITEM_NAME_TO_ID, FISHING_LICENSES, TELEPORT_ACCESS_ITEMS
 from .locations import LOCATION_DESCRIPTIONS, LOCATION_DEFINITIONS, EVENT_DEFINITIONS, ToontownLocationName, \
     ToontownLocationType, ALL_TASK_LOCATIONS_SPLIT, LOCATION_NAME_TO_ID, ToontownLocationDefinition, \
     TREASURE_LOCATION_TYPES, BOSS_LOCATION_TYPES
-from .options import ToontownOptions, TPSanity, StartingTaskOption, GagTrainingCheckBehavior, FacilityLocking
+from .options import ToontownOptions, TPSanity, StartingTaskOption, GagTrainingCheckBehavior, FacilityLocking, toontown_option_groups, WinCondition
 from .regions import REGION_DEFINITIONS, ToontownRegionName
 from .ruledefs import test_location, test_entrance, test_item_location
 from .fish import FishProgression, FishChecks
@@ -30,6 +30,7 @@ class ToontownWeb(WebWorld):
         ["DevvyDont"]
     )]
     theme = "partyTime"
+    option_groups = toontown_option_groups
 
 
 class ToontownWorld(World):
@@ -264,7 +265,14 @@ class ToontownWorld(World):
                         pool.append(item)
 
         # Dynamically generate laff boosts.
-        if self.options.win_condition.value != 5 and self.options.second_win_condition.value != 5:  # If our goal isn't laff-o-lypics, generate laff items normally
+        if self.options.win_condition_laff_o_lympics:  # Our goal is laff-o-lympics, only progressive +1 Boost items
+            # Lets make sure our goal isn't more than our max_laff
+            # If it is, make our max laff the same as our goal
+            LAFF_TO_GIVE = max(self.options.laff_points_required, self.options.max_laff.value) - self.options.starting_laff.value
+
+            for _ in range(LAFF_TO_GIVE):
+                pool.append(self.create_progression_item(ToontownItemName.LAFF_BOOST_1.value))
+        else:  # If our goal isn't laff-o-lypics, generate laff items normally
             LAFF_TO_GIVE = self.options.max_laff.value - self.options.starting_laff.value
             if LAFF_TO_GIVE < 0:
                 print(f"[Toontown - {self.multiworld.get_player_name(self.player)}] "
@@ -293,13 +301,6 @@ class ToontownWorld(World):
 
             for _ in range(LAFF_TO_GIVE):
                 pool.append(self.create_item(ToontownItemName.LAFF_BOOST_1.value))
-        else:  # Our goal is laff-o-lympics, only progressive +1 Boost items
-            # Lets make sure our goal isn't more than our max_laff
-            # If it is, make our max laff the same as our goal
-            LAFF_TO_GIVE = max(self.options.laff_points_required, self.options.max_laff.value) - self.options.starting_laff.value
-
-            for _ in range(LAFF_TO_GIVE):
-                pool.append(self.create_progression_item(ToontownItemName.LAFF_BOOST_1.value))
 
 
         # Dynamically generate training frames.
@@ -408,16 +409,18 @@ class ToontownWorld(World):
             if location.address and location.item and location.item.code and location.item.player == self.player
         ]
 
+        win_condition = ToontownWinCondition.buildFromOptions(self.options)
+
         # TODO: if actually removing tasks becomes implemented,
         #       check if there are still enough tasks to complete
 
         # If win condition is total_tasks, make sure that the player can actually complete them.
-        # if self.options.win_condition.value == 1 and self.options.total_tasks_required.value > 6*self.options.logical_tasks_per_playground.value:
+        # if self.options.win_condition_total_tasks.value and self.options.total_tasks_required.value > 6*self.options.logical_tasks_per_playground.value:
         #     raise Exception(f"[Toontown - {self.multiworld.get_player_name(self.player)}] "
         #                     f"Too many total tasks required (max is 6*logical_tasks: {6*self.options.logical_tasks_per_playground.value}), please tweak settings.")
 
         # If win condition is hood_tasks, make sure that the player can actually complete them.
-        # if self.options.win_condition.value == 2 and self.options.hood_tasks_required.value > self.options.logical_tasks_per_playground.value:
+        # if self.options.win_condition_hood_tasks.value and self.options.hood_tasks_required.value > self.options.logical_tasks_per_playground.value:
         #     raise Exception(f"[Toontown - {self.multiworld.get_player_name(self.player)}] "
         #                     f"Too many hood tasks required (max is logical_tasks: {self.options.logical_tasks_per_playground.value}), please tweak settings.")
 
@@ -435,8 +438,7 @@ class ToontownWorld(World):
             "overflow_mod": self.options.overflow_mod.value,
             "first_track": self.first_track.value,
             "second_track": self.second_track.value,
-            "win_condition": self.options.win_condition.value,
-            "second_win_condition": self.options.second_win_condition.value,
+            "win_condition": int(win_condition),
             "cog_bosses_required": self.options.cog_bosses_required.value,
             "total_tasks_required": self.options.total_tasks_required.value,
             "hood_tasks_required": self.options.hood_tasks_required.value,

--- a/apworld/toontown/consts.py
+++ b/apworld/toontown/consts.py
@@ -55,10 +55,10 @@ class ToontownWinCondition(IntFlag):
     fish_species = auto()
     laff_o_lympics = auto()
 
-    @staticmethod
-    def buildFromOptions(options):
+    @classmethod
+    def from_options(cls, options):
         """expects archipelago world options."""
-        win_conditions = ToontownWinCondition(0)
+        win_conditions = cls(0)
         if options.win_condition_cog_bosses.value:
             win_conditions = win_conditions | ToontownWinCondition.cog_bosses
         if options.win_condition_total_tasks.value:

--- a/apworld/toontown/consts.py
+++ b/apworld/toontown/consts.py
@@ -1,6 +1,7 @@
 """
 Constants for Archipelago generation.
 """
+from enum import IntFlag, auto
 from BaseClasses import Item, Location
 
 BASE_ID = 0x501100
@@ -44,3 +45,30 @@ class ToontownItem(Item):
 
 class ToontownLocation(Location):
     game: str = "Toontown"
+
+
+class ToontownWinCondition(IntFlag):
+    cog_bosses = auto()
+    total_tasks = auto()
+    hood_tasks = auto()
+    gag_tracks = auto()
+    fish_species = auto()
+    laff_o_lympics = auto()
+
+    @staticmethod
+    def buildFromOptions(options):
+        """expects archipelago world options."""
+        win_conditions = ToontownWinCondition(0)
+        if options.win_condition_cog_bosses.value:
+            win_conditions = win_conditions | ToontownWinCondition.cog_bosses
+        if options.win_condition_total_tasks.value:
+            win_conditions = win_conditions | ToontownWinCondition.total_tasks
+        if options.win_condition_hood_tasks.value:
+            win_conditions = win_conditions | ToontownWinCondition.hood_tasks
+        if options.win_condition_gag_tracks.value:
+            win_conditions = win_conditions | ToontownWinCondition.gag_tracks
+        if options.win_condition_fish_species.value:
+            win_conditions = win_conditions | ToontownWinCondition.fish_species
+        if options.win_condition_laff_o_lympics.value:
+            win_conditions = win_conditions | ToontownWinCondition.laff_o_lympics
+        return win_conditions

--- a/apworld/toontown/options.py
+++ b/apworld/toontown/options.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
-
-from Options import PerGameCommonOptions, StartInventoryPool, Range, Choice, Toggle
+from Options import PerGameCommonOptions, Range, Choice, Toggle, OptionGroup, ProgressionBalancing, Accessibility
 
 
 class TeamOption(Range):
@@ -104,47 +103,11 @@ class MaxTaskCapacityOption(Range):
     range_start = 1
     range_end = 6
     default = 4
-    
-class WinCondition(Choice):
-    """
-    Determines the condition before being able to talk to Flippy to complete the game.
-    - cog_bosses (default): Player must defeat a number of cog bosses to complete the game (determined by cog_bosses_required).
-    - total_tasks: Player must complete a total number of tasks to complete the game (determined by total_tasks_required).
-    - hood_tasks: Player must complete a number of tasks from each neighborhood to complete the game (determined by hood_tasks_required).
-    - total_fish_species:  Player must catch a certain amount of fish species to complete the game (determined by fish_species_required).
-    - laff_o_lympics: Player must reach a certain amount of laff to complete the game (determined by laff_points_required).
-    """
-    display_name = "Win Condition"
-    option_cog_bosses = 0
-    option_total_tasks = 1
-    option_hood_tasks = 2
-    option_total_gag_tracks = 3
-    option_total_fish_species = 4
-    option_laff_o_lympics = 5
-    default = 0
 
-
-class SecondWinCondition(Choice):
-    """
-    NOTE: This condition should NOT be the same as win_condition
-    Determines a second condition before being able to talk to Flippy to complete the game.
-    - none (default): Disables this option and only one condition is needed to complete the run.
-    - cog_bosses: Player must defeat a number of cog bosses to complete the game (determined by cog_bosses_required).
-    - total_tasks: Player must complete a total number of tasks to complete the game (determined by total_tasks_required).
-    - hood_tasks: Player must complete a number of tasks from each neighborhood to complete the game (determined by hood_tasks_required).
-    - total_fish_species:  Player must catch a certain amount of fish species to complete the game (determined by fish_species_required).
-    - laff_o_lympics: Player must reach a certain amount of laff to complete the game (determined by laff_points_required).
-    """
-    display_name = "Second Win Condition"
-    option_cog_bosses = 0
-    option_total_tasks = 1
-    option_hood_tasks = 2
-    option_total_gag_tracks = 3
-    option_total_fish_species = 4
-    option_laff_o_lympics = 5
-    option_none = 6
-    default = 6
-
+class WinConditionCogBosses(Toggle):
+    """Defeat a number of cog bosses to complete the game (determined by cog_bosses_required)."""
+    display_name = "Cog Bosses"
+    default = True
 
 class CogBossesRequired(Range):
     """
@@ -156,6 +119,10 @@ class CogBossesRequired(Range):
     range_end = 4
     default = 4
 
+class WinConditionTotalTasks(Toggle):
+    """Complete a total number of tasks to complete the game (determined by total_tasks_required)."""
+    display_name = "Total Tasks"
+    default = False
 
 class TotalTasksRequired(Range):
     """
@@ -168,6 +135,10 @@ class TotalTasksRequired(Range):
     range_end = 72
     default = 48
 
+class WinConditionHoodTasks(Toggle):
+    """Complete a number of tasks from each neighborhood to complete the game (determined by hood_tasks_required)."""
+    display_name = "Hood Tasks"
+    default = False
 
 class HoodTasksRequired(Range):
     """
@@ -180,6 +151,10 @@ class HoodTasksRequired(Range):
     range_end = 12
     default = 8
 
+class WinConditionTotalGagTracks(Toggle):
+    """Max a certain number of gag tracks to complete the game (determined by gag_tracks_required)."""
+    display_name = "Gag Tracks Maxed"
+    default = False
 
 class GagTracksRequired(Range):
     """
@@ -192,6 +167,10 @@ class GagTracksRequired(Range):
     range_end = 7
     default = 5
 
+class WinConditionFishSpecies(Toggle):
+    """Catch a certain amount of fish species to complete the game (determined by fish_species_required)."""
+    display_name = "Fish Species"
+    default = False
 
 class FishSpeciesRequired(Range):
     """
@@ -204,6 +183,10 @@ class FishSpeciesRequired(Range):
     range_end = 70
     default = 70
 
+class WinConditionLaffOLympics(Toggle):
+    """Reach a certain amount of laff to complete the game (determined by laff_points_required)."""
+    display_name = "Laff o lympics"
+    default = False
 
 class LaffPointsRequired(Range):
     """
@@ -216,7 +199,6 @@ class LaffPointsRequired(Range):
     range_end = 150
     default = 120
 
-    
 class TPSanity(Choice):
     """
     Determines how Teleport Access is shuffled in the Item Pool for all Playgrounds/HQs.
@@ -237,7 +219,7 @@ class TreasuresPerLocation(Range):
     """
     The amount of archipelago treasures that'll have items in each location
     """
-    display_name = "AP Treasures Per Location"
+    display_name = "Treasures Per Location"
     range_start = 0
     range_end = 6
     default = 4
@@ -266,7 +248,7 @@ class GagTrainingCheckBehavior(Choice):
     option_disabled = 2
     default = 1
 
-    display_name = "Gag Training Check Behavior"
+    display_name = "Gag Training Behavior"
 
 
 class GagTrainingFrameBehavior(Choice):
@@ -283,7 +265,7 @@ class GagTrainingFrameBehavior(Choice):
     option_trained = 2
     default = 0
 
-    display_name = "Gag Frame Item Behavior"
+    display_name = "Gag Frame Behavior"
 
 class LogicalTasksPerPlayground(Range):
     """
@@ -349,7 +331,7 @@ class FishLocations(Choice):
     - vanilla: Fish spawn in their vanilla locations. Street-exclusive fish remain in their vanilla locations.
     - global: Fish can spawn anywhere.
     """
-    display_name = "fish_locations"
+    display_name = "Fish Locations"
     option_playgrounds = 0
     option_vanilla = 1
     option_global = 2
@@ -364,7 +346,7 @@ class FishChecks(Choice):
     - all_gallery: Every 10 species will have an item.
     - none: There are no items in fishing.
     """
-    display_name = "fish_checks"
+    display_name = "Fish Checks"
     option_all_species = 0
     option_all_gallery_and_genus = 1
     option_all_gallery = 2
@@ -380,7 +362,7 @@ class FishProgression(Choice):
     - rods: Progressive fishing rod items are added to the pool.
     - none: All fishing areas are available. The player starts with a Gold Rod.
     """
-    display_name = "fish_progression"
+    display_name = "Fish Progression"
     option_licenses_and_rods = 0
     option_licenses = 1
     option_rods = 2
@@ -563,7 +545,6 @@ class DeathLinkOption(Toggle):
     display_name = "Death Link"
     default = False
 
-
 @dataclass
 class ToontownOptions(PerGameCommonOptions):
     team: TeamOption
@@ -576,8 +557,12 @@ class ToontownOptions(PerGameCommonOptions):
     starting_money: StartMoneyOption
     starting_task_capacity: StartingTaskCapacityOption
     max_task_capacity: MaxTaskCapacityOption
-    win_condition: WinCondition
-    second_win_condition: SecondWinCondition
+    win_condition_cog_bosses: WinConditionCogBosses
+    win_condition_total_tasks: WinConditionTotalTasks
+    win_condition_hood_tasks: WinConditionHoodTasks
+    win_condition_gag_tracks: WinConditionTotalGagTracks
+    win_condition_fish_species: WinConditionFishSpecies
+    win_condition_laff_o_lympics: WinConditionLaffOLympics
     cog_bosses_required: CogBossesRequired
     total_tasks_required: TotalTasksRequired
     hood_tasks_required: HoodTasksRequired
@@ -613,3 +598,32 @@ class ToontownOptions(PerGameCommonOptions):
     unite_weight: UniteWeightOption
     fire_weight: FireWeightOption
     death_link: DeathLinkOption
+
+toontown_option_groups: list[OptionGroup] = [
+    OptionGroup("Archipelago Settings", [
+        ProgressionBalancing, Accessibility, SyncJellybeans, SyncGagExp
+    ]),
+    OptionGroup("Toon Settings", [
+        TeamOption, MaxLaffOption, StartLaffOption, StartingTaskOption,
+        BaseGlobalGagXPRange, MaxGlobalGagXPRange, DamageMultiplierRange,
+        OverflowModRange, StartMoneyOption, StartingTaskCapacityOption,
+        MaxTaskCapacityOption, DeathLinkOption
+    ]),
+    OptionGroup("Win Condition", [
+        WinConditionCogBosses, CogBossesRequired,
+        WinConditionTotalTasks, TotalTasksRequired,
+        WinConditionHoodTasks, HoodTasksRequired,
+        WinConditionTotalGagTracks, GagTracksRequired,
+        WinConditionFishSpecies, FishSpeciesRequired,
+        WinConditionLaffOLympics, LaffPointsRequired
+        ], False),
+    OptionGroup("Check/Item Behavior", [
+        TPSanity, TreasuresPerLocation, ChecksPerBoss, GagTrainingCheckBehavior,
+        GagTrainingFrameBehavior, LogicalTasksPerPlayground, LogicalMaxedCogGallery,
+        MaxedCogGalleryQuota, FacilityLocking, FishChecks, FishLocations,
+        FishProgression, RacingOption, GolfingOption, SeedGenerationTypeOption
+    ], False),
+    OptionGroup("Weights", [
+        TrapPercentOption, UberWeightOption, DripWeightOption, TaxWeightOption, ShuffleWeightOption
+    ], True)
+]

--- a/apworld/toontown/options.py
+++ b/apworld/toontown/options.py
@@ -114,7 +114,7 @@ class CogBossesRequired(Range):
     How many cog bosses must be defeated before being able to talk to Flippy to complete the game.
     Unused if win_condition is not cog_bosses.
     """
-    display_name = "Cog Bosses Required"
+    display_name = "Bosses Required"
     range_start = 0
     range_end = 4
     default = 4
@@ -130,7 +130,7 @@ class TotalTasksRequired(Range):
     Must be less than total tasks in game (6 zones times logical_tasks_per_playground tasks).
     Unused if win_condition is not total_tasks.
     """
-    display_name = "Total Tasks Required"
+    display_name = "Tasks Required"
     range_start = 0
     range_end = 72
     default = 48
@@ -146,7 +146,7 @@ class HoodTasksRequired(Range):
     Must be less than logical_tasks_per_playground.
     Unused if win_condition is not hood_tasks.
     """
-    display_name = "Hood Tasks Required"
+    display_name = "Hood Tasks Count"
     range_start = 0
     range_end = 12
     default = 8
@@ -162,7 +162,7 @@ class GagTracksRequired(Range):
     Must be less than or equal to total number of gag tracks a toon can obtain.
     Unused if win_condition is not total_gag_tracks
     """
-    display_name = "Gag Tracks Required"
+    display_name = "Tracks Required"
     range_start = 0
     range_end = 7
     default = 5
@@ -178,7 +178,7 @@ class FishSpeciesRequired(Range):
     Must be less than or equal to total number of fish species a toon can obtain.
     Unused if win_condition is not total_fish_species
     """
-    display_name = "Fish Species Required"
+    display_name = "Fish Required"
     range_start = 0
     range_end = 70
     default = 70
@@ -194,7 +194,7 @@ class LaffPointsRequired(Range):
     Setting must be below or equal to max_laff setting
     Unused if win_condition is not laff_o_lympics
     """
-    display_name = "Laff Points Required"
+    display_name = "Laff Required"
     range_start = 0
     range_end = 150
     default = 120
@@ -406,7 +406,7 @@ class SyncGagExp(Toggle):
     leaving this on will retain your gag experience if you need to make a new toon to reconnect.
     If this is 'false', the data will still be sent, but your toon will not sync with it.
     """
-    display_name = "Sync Gag Experience"
+    display_name = "Sync Gag Exp"
     default = True
 
 
@@ -624,6 +624,7 @@ toontown_option_groups: list[OptionGroup] = [
         FishProgression, RacingOption, GolfingOption, SeedGenerationTypeOption
     ], False),
     OptionGroup("Weights", [
-        TrapPercentOption, UberWeightOption, DripWeightOption, TaxWeightOption, ShuffleWeightOption
+        TrapPercentOption, UberWeightOption, DripWeightOption, TaxWeightOption, ShuffleWeightOption,
+        BeanWeightOption, GagExpWeightOption, SOSWeightOption, UniteWeightOption, FireWeightOption
     ], True)
 ]

--- a/apworld/toontown/ruledefs.py
+++ b/apworld/toontown/ruledefs.py
@@ -6,7 +6,7 @@ from .consts import XP_RATIO_FOR_GAG_LEVEL, ToontownItem, CAP_RATIO_FOR_GAG_LEVE
 from .fish import LOCATION_TO_GENUS_SPECIES, FISH_DICT, FishProgression, FishLocation, get_catchable_fish, \
     LOCATION_TO_GENUS, FISH_ZONE_TO_LICENSE, FishZone, FISH_ZONE_TO_REGION, PlaygroundFishZoneGroups
 from .items import ToontownItemName
-from .options import ToontownOptions, TPSanity, FacilityLocking, SecondWinCondition
+from .options import ToontownOptions, TPSanity, FacilityLocking
 from .locations import ToontownLocationDefinition, ToontownLocationName, LOCATION_NAME_TO_ID, FISH_LOCATIONS, \
     get_location_def_from_name
 from .regions import ToontownEntranceDefinition, ToontownRegionName
@@ -648,7 +648,7 @@ def MaxedAllGags(state: CollectionState, locentr: LocEntrDef, world: MultiWorld,
 @rule(Rule.CanWinGame)
 def CanWinGame(state: CollectionState, locentr: LocEntrDef, world: MultiWorld, player: int, options, argument: Tuple = None):
     if isinstance(options, ToontownOptions):
-        win_condition = ToontownWinCondition.buildFromOptions(options)
+        win_condition = ToontownWinCondition.from_options(options)
     else:
         win_condition = ToontownWinCondition(options.get("win_condition", 0))
     args = (state, locentr, world, player, options)

--- a/toontown/archipelago/packets/clientbound/connected_packet.py
+++ b/toontown/archipelago/packets/clientbound/connected_packet.py
@@ -179,13 +179,7 @@ class ConnectedPacket(ClientBoundPacketBase):
         # Tell AP we are playing
         won_id = ap_location_name_to_id(locations.ToontownLocationName.SAVED_TOONTOWN.value)
         status_packet = StatusUpdatePacket()
-        conditions = client.av.getWinCondition()
-        won_game = True
-        for condition in conditions:
-            if not condition.satisfied():
-                won_game = False
-                break
-        status_packet.status = ClientStatus.CLIENT_GOAL if (won_game and client.av.hasCheckedLocation(won_id)) else ClientStatus.CLIENT_PLAYING
+        status_packet.status = ClientStatus.CLIENT_GOAL if (client.av.hasCheckedLocation(won_id)) else ClientStatus.CLIENT_PLAYING
         client.send_packet(status_packet)
 
         # Scout some locations that we need to display

--- a/toontown/archipelago/packets/clientbound/room_info_packet.py
+++ b/toontown/archipelago/packets/clientbound/room_info_packet.py
@@ -84,8 +84,6 @@ class RoomInfoPacket(ClientBoundPacketBase):
         client.av.hintCostPercentage = self.hint_cost
 
 
-        print(self.seed_name)
-        print(type(self.seed_name))
         # Check if this is the last session we connected to.
         if client.av.checkLastSeed(self.seed_name):
             client.av.b_setLastSeed(self.seed_name)

--- a/toontown/archipelago/util/win_condition.py
+++ b/toontown/archipelago/util/win_condition.py
@@ -82,8 +82,7 @@ class BossDefeatWinCondition(WinCondition):
 
     def generate_npc_dialogue(self, delimiter='\x07') -> str:
         if self.satisfied():
-            return delimiter.join(['It seems your bosses goal is completed!',
-                    'When you finish your other goal, come back and see me!'])
+            return 'It seems your bosses goal is completed!'
         return delimiter.join(['You still have not completed your bosses goal!',
                 f'You still must defeat {self.__get_bosses_needed()} unique bosses.'])
 

--- a/toontown/toon/DistributedNPCFlippyInToonHall.py
+++ b/toontown/toon/DistributedNPCFlippyInToonHall.py
@@ -39,7 +39,7 @@ class DistributedNPCFlippyInToonHall(DistributedNPCToon):
         if avId == base.localAvatar.doId:
             self.__doLocalToonVictory()
 
-        fullString = "You have completed your goal!\x07You may now use !release to give the other players in your multi-world the items that you haven't found yet.\x07Thank you for playing!"
+        fullString = toon.winCondition.generate_npc_victory_dialogue(delimiter='\x07')
         self.setupAvatars(toon)
         self.acceptOnce(self.uniqueName('doneChatPage'), self.finishMovie, extraArgs=[toon, isLocalToon])
         self.clearChat()
@@ -74,14 +74,7 @@ class DistributedNPCFlippyInToonHall(DistributedNPCToon):
 
     def doVictoryConditionNotMetMovie(self, toon: DistributedToon.DistributedToon):
         isLocalToon = toon.doId == base.localAvatar.doId
-        npcDialogue = ''
-        conditions = toon.getWinCondition()
-        for condition in conditions:
-            npcDialogue = npcDialogue + condition.generate_npc_dialogue(delimiter='\x07')
-            npcDialogue = npcDialogue + (f'\x07')
-            if conditions.index(condition) == (len(conditions) - 1):
-                npcDialogue = npcDialogue + (f'Good luck!')
-
+        npcDialogue = toon.getWinCondition().generate_npc_dialogue(delimiter='\x07') + '\x07When you finish, come back and see me!\x07Good luck!'
         if isLocalToon:
             self.setupCamera(None)
 

--- a/toontown/toon/DistributedNPCFlippyInToonHallAI.py
+++ b/toontown/toon/DistributedNPCFlippyInToonHallAI.py
@@ -20,15 +20,10 @@ class DistributedNPCFlippyInToonHallAI(DistributedNPCToonAI):
             return
 
         # If they have not beat their game, reject them
-        hasWon = True
-        for condition in toon.getWinCondition():
-            if not condition.satisfied():
-                hasWon = False
-                break
-        if not hasWon:
-            return self.rejectAvatar(avId)
-
-        self.doAvatarVictory(toon)
+        if toon.getWinCondition().satisfied():
+            self.doAvatarVictory(toon)
+        else:
+            self.rejectAvatar(avId)
 
     # We reject the avatar when their completion condition isn't met
     def rejectAvatar(self, avId):

--- a/toontown/toon/DistributedToonAI.py
+++ b/toontown/toon/DistributedToonAI.py
@@ -50,10 +50,8 @@ from ..archipelago.definitions.util import get_zone_discovery_id
 from ..archipelago.util import win_condition
 from ..archipelago.util.HintContainer import HintedItem
 from ..archipelago.util.location_scouts_cache import LocationScoutsCache
-from ..archipelago.util.win_condition import WinCondition
 from ..shtiker import CogPageGlobals
 from ..util.astron.AstronDict import AstronDict
-from apworld.toontown.options import SecondWinCondition
 
 if simbase.wantPets:
     from toontown.pets import PetLookerAI, PetObserve
@@ -245,7 +243,7 @@ class DistributedToonAI(DistributedPlayerAI.DistributedPlayerAI, DistributedSmoo
         self.apMessageQueue: DistributedToonAPMessageQueue = DistributedToonAPMessageQueue(self)
         self.deathReason: DeathReason = DeathReason.UNKNOWN
         self.slotData = {}  # set in connected_packet.py
-        self.winCondition = [win_condition.NoWinCondition(self)]
+        self.winCondition = win_condition.NoWinCondition(self)
 
     def generate(self):
         DistributedPlayerAI.DistributedPlayerAI.generate(self)
@@ -4648,7 +4646,7 @@ class DistributedToonAI(DistributedPlayerAI.DistributedPlayerAI, DistributedSmoo
         self.b_setCheckedLocations([])
         self.b_setReceivedItems([])
         self.b_setAccessKeys([])
-        
+
         # Regenerate the toon's UUID used for archipelago connections.
         self.regenerateUUID()
 
@@ -4695,13 +4693,9 @@ class DistributedToonAI(DistributedPlayerAI.DistributedPlayerAI, DistributedSmoo
         self.archipelago_session.toon_died()
 
     def updateWinCondition(self) -> None:
-        condition = []
-        condition.append(win_condition.generate_win_condition(self.slotData.get('win_condition', -2), self))
-        if self.slotData.get('second_win_condition', SecondWinCondition.option_none) != SecondWinCondition.option_none:
-            condition.append(win_condition.generate_win_condition(self.slotData.get('second_win_condition', -2), self))
-        self.winCondition = condition
+        self.winCondition = win_condition.generate_win_condition(self.slotData.get('win_condition', -2), self)
 
-    def getWinCondition(self) -> WinCondition:
+    def getWinCondition(self) -> win_condition.WinCondition:
         return self.winCondition
     
     # UUID for use with archipelago, stored in the toon for use as an identifier.


### PR DESCRIPTION
Allows any number of win conditions, logic was only tested by looking at spoiler logs, but appears fine.
This also refactors most of toontown.archipelago.utils.win_condition while I was already in there doing notable changes to all of it.

Adds OptionGroups to the Options, for the sake of making the WebHost's Game Options page look cleaner.