### PR TITLE
Gag Training: Correct experience gained when recieving a training frame.

### DIFF
--- a/toontown/archipelago/definitions/rewards.py
+++ b/toontown/archipelago/definitions/rewards.py
@@ -212,8 +212,14 @@ class GagTrainingFrameReward(APReward):
         # Otherwise increment the gag level allowed
         av.setTrackAccessLevel(self.track, newLevel)
 
+        # Max the gag and give the new gag if the behavior mode is to max gags 
+        if behaviorMode == GagTrainingFrameBehavior.option_trained and newLevel < 8:
+            av.experience.setExp(self.track, av.experience.getExperienceCapForTrack(track=self.track)) # max the gag exp.
+            av.ap_setExperience(av.experience.getCurrentExperience())
+            av.inventory.addItemsWithListMax([(self.track, newLevel-1)])  # Give the new gags!!
+            av.b_setInventory(av.inventory.makeNetString())
         # Consider the case where we just learned a new gag track, we should give them as many of them as possible
-        if newLevel == 1:
+        elif newLevel == 1:
             av.inventory.addItemsWithListMax([(self.track, 0)])
             av.b_setInventory(av.inventory.makeNetString())
         # Now consider the case where we were maxed previously and want to upgrade by giving 1 xp and giving new gags
@@ -222,12 +228,6 @@ class GagTrainingFrameReward(APReward):
             or behaviorMode == GagTrainingFrameBehavior.option_unlock and newLevel < 8):
             toNext = av.experience.getNextExpValue(track=self.track, curSkill=curExp)
             av.experience.setExp(track=self.track, exp=toNext)  # Give them enough xp to learn the gag :)
-            av.ap_setExperience(av.experience.getCurrentExperience())
-            av.inventory.addItemsWithListMax([(self.track, newLevel-1)])  # Give the new gags!!
-            av.b_setInventory(av.inventory.makeNetString())
-        # Using an if here because this still should run to max level 1 gags.
-        if behaviorMode == GagTrainingFrameBehavior.option_trained and newLevel < 8:
-            av.experience.setExp(self.track, av.experience.getExperienceCapForTrack(track=self.track)) # max the gag exp.
             av.ap_setExperience(av.experience.getCurrentExperience())
             av.inventory.addItemsWithListMax([(self.track, newLevel-1)])  # Give the new gags!!
             av.b_setInventory(av.inventory.makeNetString())

--- a/toontown/archipelago/definitions/rewards.py
+++ b/toontown/archipelago/definitions/rewards.py
@@ -7,6 +7,7 @@ from typing import List, Tuple
 
 from apworld.toontown import ToontownItemName, get_item_def_from_id
 from apworld.toontown.fish import LICENSE_TO_ACCESS_CODE
+from apworld.toontown.options import GagTrainingFrameBehavior
 from otp.otpbase.OTPLocalizerEnglish import EmoteFuncDict
 from toontown.archipelago.util import global_text_properties
 from toontown.archipelago.util.global_text_properties import MinimalJsonMessagePart
@@ -208,7 +209,7 @@ class GagTrainingFrameReward(APReward):
         if newLevel >= 8:
             wasCapped = False
 
-        # Otherwise increment the gag level allowed and make sure it is not organic
+        # Otherwise increment the gag level allowed
         av.setTrackAccessLevel(self.track, newLevel)
 
         # Consider the case where we just learned a new gag track, we should give them as many of them as possible
@@ -217,14 +218,15 @@ class GagTrainingFrameReward(APReward):
             av.b_setInventory(av.inventory.makeNetString())
         # Now consider the case where we were maxed previously and want to upgrade by giving 1 xp and giving new gags
         # This will also trigger the new gag check to unlock :3
-        elif (wasCapped and behaviorMode == 0) or behaviorMode == 1:
+        elif (wasCapped and behaviorMode == GagTrainingFrameBehavior.option_vanilla
+            or behaviorMode == GagTrainingFrameBehavior.option_unlock and newLevel < 8):
             toNext = av.experience.getNextExpValue(track=self.track, curSkill=curExp)
-            av.experience.addExp(track=self.track, amount=toNext)  # Give them enough xp to learn the gag :)
+            av.experience.setExp(track=self.track, exp=toNext)  # Give them enough xp to learn the gag :)
             av.ap_setExperience(av.experience.getCurrentExperience())
             av.inventory.addItemsWithListMax([(self.track, newLevel-1)])  # Give the new gags!!
             av.b_setInventory(av.inventory.makeNetString())
         # Using an if here because this still should run to max level 1 gags.
-        if behaviorMode == 2 and newLevel < 8: # Train Gag when recieving frame.
+        if behaviorMode == GagTrainingFrameBehavior.option_trained and newLevel < 8:
             av.experience.setExp(self.track, av.experience.getExperienceCapForTrack(track=self.track)) # max the gag exp.
             av.ap_setExperience(av.experience.getCurrentExperience())
             av.inventory.addItemsWithListMax([(self.track, newLevel-1)])  # Give the new gags!!

--- a/toontown/archipelago/definitions/rewards.py
+++ b/toontown/archipelago/definitions/rewards.py
@@ -205,15 +205,16 @@ class GagTrainingFrameReward(APReward):
         # Before we do anything, we need to see if they were capped before this so we can award them gags later
         curExp = av.experience.getExp(self.track)
         wasCapped = curExp == av.experience.getExperienceCapForTrack(self.track)
-        # Edge case, we were not technically capped if we are unlocking the "overflow xp" mechanic
-        if newLevel >= 8:
-            wasCapped = False
 
         # Otherwise increment the gag level allowed
         av.setTrackAccessLevel(self.track, newLevel)
 
+        # Edge case, nothing else should happen if we are unlocking the "overflow xp" mechanic
+        if newLevel >= 8:
+            return
+
         # Max the gag and give the new gag if the behavior mode is to max gags 
-        if behaviorMode == GagTrainingFrameBehavior.option_trained and newLevel < 8:
+        elif behaviorMode == GagTrainingFrameBehavior.option_trained:
             av.experience.setExp(self.track, av.experience.getExperienceCapForTrack(track=self.track)) # max the gag exp.
             av.ap_setExperience(av.experience.getCurrentExperience())
             av.inventory.addItemsWithListMax([(self.track, newLevel-1)])  # Give the new gags!!
@@ -225,7 +226,7 @@ class GagTrainingFrameReward(APReward):
         # Now consider the case where we were maxed previously and want to upgrade by giving 1 xp and giving new gags
         # This will also trigger the new gag check to unlock :3
         elif (wasCapped and behaviorMode == GagTrainingFrameBehavior.option_vanilla
-            or behaviorMode == GagTrainingFrameBehavior.option_unlock and newLevel < 8):
+            or behaviorMode == GagTrainingFrameBehavior.option_unlock):
             toNext = av.experience.getNextExpValue(track=self.track, curSkill=curExp)
             av.experience.setExp(track=self.track, exp=toNext)  # Give them enough xp to learn the gag :)
             av.ap_setExperience(av.experience.getCurrentExperience())


### PR DESCRIPTION
Solves an issue where gag frames would cause the toon to receive much more experience than necessary to reach the next gag, on both 'vanilla' and 'unlock' gag frame behavior modes.