### PR TITLE
Archipelago: Consistency with AP 0.5.0 behavior, small refactor of ArchipelagoClient

### DIFF
--- a/toontown/archipelago/packets/clientbound/data_package_packet.py
+++ b/toontown/archipelago/packets/clientbound/data_package_packet.py
@@ -50,18 +50,6 @@ class DataPackagePacket(ClientBoundPacketBase):
             game_name: str
             game_data: GameData
 
-            # Construct an actual game_data packet
-            package = DataPackage()
-            package.game = game_name
-            package.checksum = game_data['checksum']
-
-            # Our datapackage is stored in reverse order for our location/item keys
-            package.id_to_item_name = {int(v): k for k, v in game_data['item_name_to_id'].items()}
-            package.id_to_location_name = {int(v): k for k, v in game_data['location_name_to_id'].items()}
-
-            # Cache this package, and have our client store it
-            package.cache()
-            client.data_packages[game_name] = package
-            client.global_data_package.merge(package)
-
-
+            # Construct an actual game_data package and store it for use
+            package = DataPackage.load(game_name, game_data)
+            client.global_data_package.add_datapackage(package)

--- a/toontown/archipelago/packets/clientbound/print_json_packet.py
+++ b/toontown/archipelago/packets/clientbound/print_json_packet.py
@@ -41,7 +41,7 @@ class PrintJSONPacket(ClientBoundPacketBase):
         Reads this packet when we know for sure it is a hint packet. Will cause errors if this packet is not a hint
         packet, use self.is_hint_packet() before calling this
         """
-        location_name = client.get_location_name(self.item.location)
+        location_name = client.get_location_name(self.item.location, self.item.player)
         player_name = client.get_player_name(self.item.player)
         return HintedItem(self.receiving, self.item, player_name, location_name, self.found)
 

--- a/toontown/archipelago/packets/clientbound/received_items_packet.py
+++ b/toontown/archipelago/packets/clientbound/received_items_packet.py
@@ -35,7 +35,7 @@ class ReceivedItemsPacket(ClientBoundPacketBase):
 
             # If we need to apply it go ahead and keep track on the toon that we applied this specific reward
             if not_applied_yet:
-                itemName = client.get_item_info(item.item)
+                itemName = client.get_item_name(item.item, client.get_local_slot())
                 fromName = client.get_slot_info(item.player).name
                 ap_reward_definition: APReward = get_ap_reward_from_id(item.item)
                 reward: EarnedAPReward = EarnedAPReward(client.av, ap_reward_definition, reward_index, item.item, fromName, item.player == client.slot)

--- a/toontown/archipelago/packets/clientbound/room_info_packet.py
+++ b/toontown/archipelago/packets/clientbound/room_info_packet.py
@@ -57,13 +57,10 @@ class RoomInfoPacket(ClientBoundPacketBase):
                 package = DataPackage.from_cache(checksum)
 
                 # Otherwise, we can add this to the client
-                client.data_packages[game_name] = package
-                client.global_data_package.merge(package)
+                client.global_data_package.add_datapackage(package)
                 self.debug(f"Loaded DataPackage for {game_name} from cache!")
-            except:
-                self.debug(f"Missing DataPackage for {game_name}")
-
-            if not package:
+            except OSError:
+                self.debug(f"Failed opening DataPackage for {game_name} from cache.")
                 missing_games.append(game_name)
 
         # Send the packets if we need to get some game info
@@ -84,7 +81,7 @@ class RoomInfoPacket(ClientBoundPacketBase):
         client.av.hintCostPercentage = self.hint_cost
 
 
-        # Check if this is the last session we connected to.
+        # # Check if this is the last session we connected to.
         if client.av.checkLastSeed(self.seed_name):
             client.av.b_setLastSeed(self.seed_name)
             # When we are given this packet, we should attempt to connect this player to the room with their slot

--- a/toontown/archipelago/util/data_package.py
+++ b/toontown/archipelago/util/data_package.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 
 class DataPackage:
-
     def __init__(self):
         self.game = ''
         self.version = -1
@@ -20,50 +19,43 @@ class DataPackage:
     def get_location_from_id(self, location_id: Union[int, str]) -> str:
         return self.id_to_location_name.get(int(location_id), f'Unknown Location[{location_id}]')
 
-    # Take in another datapackage, and merge all mappings from that one into this one THIS IS NOT OVERWRITE SAFE
-    # Used to have a master package for all games where the instance calling merge() will have all keys
-    def merge(self, other: "DataPackage") -> None:
+    @classmethod
+    def load(cls, name: str, data: Dict[str,any]):
+        """
+        Load and cache a game's datapackage to disk.
+        """
+        instance = cls()
 
-        for item_id, name in other.id_to_item_name.items():
-            self.id_to_item_name[item_id] = name
-
-        for location_id, name in other.id_to_location_name.items():
-            self.id_to_location_name[location_id] = name
-
-    # Stores this datapackage on disk
-    def cache(self):
+        instance.game = name
+        instance.version = data.get('version', -1)
+        instance.checksum = data['checksum']
+        instance.id_to_item_name = {int(v): k for k, v in data['item_name_to_id'].items()}
+        instance.id_to_location_name = {int(v): k for k, v in data['location_name_to_id'].items()}
 
         # Create a python dict version of this object that can be read later via json
         data = {
-            'game': self.game,
-            'version': self.version,
-            'checksum': self.checksum,
-            'items': self.id_to_item_name,
-            'locations': self.id_to_location_name
+            'game': instance.game,
+            'version': instance.version,
+            'checksum': instance.checksum,
+            'items': instance.id_to_item_name,
+            'locations': instance.id_to_location_name
         }
 
-        Path(f'output/datapackages').mkdir(parents=True, exist_ok=True)
-        with open(f'output/datapackages/{self.checksum}.json', 'w') as f:
+        Path('output/datapackages').mkdir(parents=True, exist_ok=True)
+        with open(f'output/datapackages/{instance.checksum}.json', 'w', encoding='utf-8') as f:
             json.dump(data, f, indent=4)
 
-    # Given a data package checksum, check if we already cached this data package earlier
-    @classmethod
-    def is_cached(cls, checksum: str) -> bool:
+        return instance
 
-        try:
-            f = open(f'output/datapackages/{checksum}.json')
-            f.close()
-            return True
-        except FileNotFoundError:
-            return False
-
-    # Given a checksum, load up a new DataPackage instance, throws FileNotFoundException if it doesn't exist
-    # Use is_cached() first to make sure
     @classmethod
     def from_cache(cls, checksum: str):
-        instance = cls()
+        """
+        Given a checksum, load up a new DataPackage instance.
+        Raises FileNotFoundException if it doesn't exist, OSError with any error opening it.
+        """
 
-        with open(f'output/datapackages/{checksum}.json') as f:
+        with open(f'output/datapackages/{checksum}.json', encoding='utf-8') as f:
+            instance = cls()
             data = json.load(f)
 
             instance.game = data['game']
@@ -72,3 +64,53 @@ class DataPackage:
             instance.id_to_item_name = {int(k): v for k, v in data['items'].items()}
             instance.id_to_location_name = {int(k): v for k, v in data['locations'].items()}
             return instance
+
+class GlobalDataPackage:
+    def __init__(self):
+        self._games: Dict[DataPackage] = {}
+
+    def add_datapackage(self, data: DataPackage):
+        """
+        Add a datapackage to this.
+        """
+        self._games.update({data.game: data})
+
+    def get_item_from_id(self, item_id: Union[int, str]) -> str:
+        """
+        Get an item with a given id, provided for compatibility with existing code.
+        please use get_item instead.
+        """
+        item_id = int(item_id)
+        for game in self._games.values():
+            try:
+                return game.items[item_id]
+            except KeyError:
+                continue
+        return f'Unknown Item[{item_id}]'
+
+    def get_location_from_id(self, location_id: Union[int, str]) -> str:
+        """
+        Get a location with a given id, provided for compatibility with existing code.
+        please use get_location instead.
+        """
+        location_id = int(location_id)
+        for game in self._games.values():
+            try:
+                return game.locations[location_id]
+            except KeyError:
+                continue
+        return f'Unknown Location[{location_id}]'
+
+    def get_item(self, game: str, item_id: Union[int, str]) -> str:
+        """
+        Get an item from a given game.
+        Raises KeyError if the game doesn't exist.
+        """
+        return self._games[game].get_item_from_id(int(item_id))
+
+    def get_location(self, game: str, location_id: Union[int, str]) -> str:
+        """
+        Get a location from a given game.
+        Raises KeyError if the game doesn't exist.
+        """
+        return self._games[game].get_location_from_id(int(location_id))

--- a/toontown/archipelago/util/net_utils.py
+++ b/toontown/archipelago/util/net_utils.py
@@ -246,21 +246,22 @@ class JSONPartFormatter:
             part_type = part['type'] if 'type' in part else 'default'
 
             # Switch statement basically on how we should handle the types of parts
-            if part_type in ('player_id', 'player_name'):
-                self.handle_player_part(new_part)
-            elif part_type in ('item_id', 'item_name'):
-                self.handle_item_part(new_part)
-            elif part_type in ('location_id', 'location_name'):
-                self.handle_location_part(new_part)
-            elif part_type == 'entrance_name':
-                self.handle_entrance_part(new_part)
-            elif part_type in ('default', 'text'):
-                self.handle_default_part(new_part)
-            elif part_type == 'color':  # No need to do anything, color is already defined
-                pass
-            else:
-                print(f"Unknown JSONMessagePart type: {part_type}, reverting to default part behavior")
-                self.handle_default_part(new_part)
+            match part_type:
+                case 'player_id' | 'player_name':
+                    self.handle_player_part(new_part)
+                case 'item_id' | 'item_name':
+                    self.handle_item_part(new_part)
+                case 'location_id' | 'location_name':
+                    self.handle_location_part(new_part)
+                case 'entrance_name':
+                    self.handle_entrance_part(new_part)
+                case 'default' | 'text':
+                    self.handle_default_part(new_part)
+                case 'color':  # No need to do anything, color is already defined
+                    pass
+                case _:
+                    print(f"Unknown JSONMessagePart type: {part_type}, reverting to default part behavior")
+                    self.handle_default_part(new_part)
 
             new_parts.append(new_part)
 
@@ -292,7 +293,7 @@ class JSONPartFormatter:
 
         # If we were given the ID, override the text
         if part['type'] == 'item_id':
-            part['text'] = self.client.get_item_name(item)
+            part['text'] = self.client.get_item_name(item, part['player'])
 
         # If we were given name, instead of ID, do same thing basically
         elif part['type'] == 'item_name':
@@ -308,7 +309,7 @@ class JSONPartFormatter:
 
         # If we were given the ID, override the text
         if part['type'] == 'location_id':
-            part['text'] = self.client.get_location_name(location)
+            part['text'] = self.client.get_location_name(location, part['player'])
 
         # If we were given name, instead of ID, do same thing basically
         elif part['type'] == 'location_name':
@@ -388,7 +389,7 @@ class JSONtoTextParser(metaclass=HandlerMeta):
 
     def _handle_item_id(self, node: JSONMessagePart):
         item_id = int(node["text"])
-        node["text"] = self.client.get_item_name(item_id)
+        node["text"] = self.client.get_item_name(item_id, node['player'])
         return self._handle_item_name(node)
 
     def _handle_location_name(self, node: JSONMessagePart):
@@ -397,7 +398,7 @@ class JSONtoTextParser(metaclass=HandlerMeta):
 
     def _handle_location_id(self, node: JSONMessagePart):
         item_id = int(node["text"])
-        node["text"] = self.client.get_location_name(item_id)
+        node["text"] = self.client.get_location_name(item_id, node['player'])
         return self._handle_location_name(node)
 
     def _handle_entrance_name(self, node: JSONMessagePart):


### PR DESCRIPTION
# **Please review before merging this, it's notable changes to ArchipelagoClient, and seems to function locally.**

* Changes datapackage implementation for separating stored packages. raises a warning if calling client.get_item_name with an invalid slot and returning a default value.
  * This fixes issues of overlapping IDs causing the wrong name of locations and items being printed - since AP as of 0.5.0 officially allows different games to overlap.
* removed duplicated functions in client with identical functionality, and replaced references accordingly:
  * get_item_info in favor of get_item_name
  * get_location_info in favor of get_item_name
* Refactored some of the code in ArchipelagoClient (EAFP over LBYL when calls shouldn't fail, move comments about a function's functionality to docstrings)
* Increased max_size on the AP connection to 16MB (matching what AP sets it to, at least as of around 0.4.6 as well) from the previous default of approximately 1MB, the connection would just drop when we get sent a packet that's too large, of which I have seen at least one datapackage that does so on it's own.