### PR TITLE
Archipelago: Add item groups for most items.

### DIFF
--- a/apworld/EXAMPLE_TOONTOWN.yaml
+++ b/apworld/EXAMPLE_TOONTOWN.yaml
@@ -261,10 +261,7 @@ Toontown:
 
   # Starting hints for Cog Disguises
   start_hints:
-    - Sellbot Disguise
-    - Cashbot Disguise
-    - Lawbot Disguise
-    - Bossbot Disguise
+    - Cog Disguises
 
 game: Toontown
 requires:

--- a/apworld/toontown/__init__.py
+++ b/apworld/toontown/__init__.py
@@ -8,7 +8,7 @@ from worlds.generic.Rules import set_rule
 from . import regions, consts
 from .consts import ToontownItem, ToontownLocation, ToontownWinCondition
 from .items import ITEM_DESCRIPTIONS, ITEM_DEFINITIONS, ToontownItemDefinition, get_item_def_from_id, ToontownItemName, \
-    ITEM_NAME_TO_ID, FISHING_LICENSES, TELEPORT_ACCESS_ITEMS, FACILITY_KEY_ITEMS
+    ITEM_NAME_TO_ID, FISHING_LICENSES, TELEPORT_ACCESS_ITEMS, FACILITY_KEY_ITEMS, ITEM_NAME_GROUPS
 from .locations import LOCATION_DESCRIPTIONS, LOCATION_DEFINITIONS, EVENT_DEFINITIONS, ToontownLocationName, \
     ToontownLocationType, ALL_TASK_LOCATIONS_SPLIT, LOCATION_NAME_TO_ID, ToontownLocationDefinition, \
     TREASURE_LOCATION_TYPES, BOSS_LOCATION_TYPES
@@ -51,6 +51,7 @@ class ToontownWorld(World):
 
     location_descriptions = LOCATION_DESCRIPTIONS
     item_descriptions = ITEM_DESCRIPTIONS
+    item_name_groups = ITEM_NAME_GROUPS
 
     def __init__(self, world, player):
         super(ToontownWorld, self).__init__(world, player)

--- a/apworld/toontown/items.py
+++ b/apworld/toontown/items.py
@@ -278,6 +278,12 @@ GAG_UPGRADES = (
     ToontownItemName.DROP_UPGRADE
 )
 
+GAG_CAPACITY = (
+    ToontownItemName.GAG_CAPACITY_5,
+    ToontownItemName.GAG_CAPACITY_10,
+    ToontownItemName.GAG_CAPACITY_15
+)
+
 FISHING_LICENSES = (
     ToontownItemName.TTC_FISHING,
     ToontownItemName.DD_FISHING,
@@ -285,6 +291,7 @@ FISHING_LICENSES = (
     ToontownItemName.MML_FISHING,
     ToontownItemName.TB_FISHING,
     ToontownItemName.DDL_FISHING,
+    # ToontownItemName.FISHING_ROD_UPGRADE
 )
 TELEPORT_ACCESS_ITEMS = (
     ToontownItemName.TTC_ACCESS,
@@ -316,6 +323,66 @@ FACILITY_KEY_ITEMS = (
     ToontownItemName.BACK_THREE_ACCESS,
 )
 
+LAFF_BOOSTS = (
+    ToontownItemName.LAFF_BOOST_1,
+    ToontownItemName.LAFF_BOOST_2,
+    ToontownItemName.LAFF_BOOST_3,
+    ToontownItemName.LAFF_BOOST_4,
+    ToontownItemName.LAFF_BOOST_5
+)
+
+TRAINING_BOOSTS = (
+    ToontownItemName.GAG_MULTIPLIER_1,
+    ToontownItemName.GAG_MULTIPLIER_2
+)
+
+ACTIVITY_KEYS = (
+    ToontownItemName.GOLF_PUTTER,
+    ToontownItemName.GO_KART
+)
+
+REWARD_BUNDLES = (
+    ToontownItemName.SOS_REWARD,
+    ToontownItemName.UNITE_REWARD,
+    ToontownItemName.PINK_SLIP_REWARD
+)
+
+TRAPS = (
+    ToontownItemName.DRIP_TRAP,
+    ToontownItemName.UBER_TRAP,
+    ToontownItemName.BEAN_TAX_TRAP_1000,
+    ToontownItemName.BEAN_TAX_TRAP_1250,
+    ToontownItemName.BEAN_TAX_TRAP_750,
+    ToontownItemName.GAG_SHUFFLE_TRAP
+)
+
+COG_DISGUISES = (
+    ToontownItemName.SELLBOT_DISGUISE,
+    ToontownItemName.CASHBOT_DISGUISE,
+    ToontownItemName.LAWBOT_DISGUISE,
+    ToontownItemName.BOSSBOT_DISGUISE
+)
+
+GAG_EXP = (
+    ToontownItemName.XP_10,
+    ToontownItemName.XP_15,
+    ToontownItemName.XP_20
+)
+
+JELLYBEANS = (
+    ToontownItemName.MONEY_150,
+    ToontownItemName.MONEY_400,
+    ToontownItemName.MONEY_700,
+    ToontownItemName.MONEY_1000
+)
+
+JELLYBEAN_CAPACITY = (
+    ToontownItemName.MONEY_CAP_1000,
+)
+
+TASK_CAPACITY = (
+    ToontownItemName.TASK_CAPACITY,
+)
 
 def hood_to_tp_item_name(hoodId: int) -> ToontownItemName:
     return {
@@ -343,3 +410,25 @@ def get_item_def_from_id(_id: int) -> Optional[ToontownItemDefinition]:
 
 
 ITEM_NAME_TO_ID = {item.name.value: i + consts.BASE_ID for i, item in enumerate(ITEM_DEFINITIONS)}
+
+
+ITEM_NAME_GROUPS_OBJECT = {
+    "Cog Disguises": COG_DISGUISES,
+    "Facility Keys": FACILITY_KEY_ITEMS,
+    "Access Keys": TELEPORT_ACCESS_ITEMS,
+    "Gag Training Frames": GAG_TRAINING_FRAMES,
+    "Gag Capacity Increase": GAG_CAPACITY,
+    "Gag Training Boosts": TRAINING_BOOSTS,
+    "Gag Upgrades": GAG_UPGRADES,
+    "Fishing Licenses": FISHING_LICENSES,
+    "Jellybean Capacity": JELLYBEAN_CAPACITY,
+    "Side Activity Keys": ACTIVITY_KEYS,
+    "Task Capacity": TASK_CAPACITY,
+    "Laff Boosts": LAFF_BOOSTS,
+    "Reward Bundles": REWARD_BUNDLES,
+    "Jellybeans": JELLYBEANS,
+    "Gag Exp Reward": GAG_EXP,
+    "Traps": TRAPS,
+}
+
+ITEM_NAME_GROUPS = {k:[i.value for i in v] for k,v in ITEM_NAME_GROUPS_OBJECT.items()}


### PR DESCRIPTION
This mostly benefits the web options page, and some of the groups are only useful there, as they only contain one item, but also additionally allows things like `!hint Access Keys` to hint the first access key in logic, regardless of where it's for.

Tested generation with it, and with the changed start hints in the yaml, and it hints all the disguises as expected.

Groups open to change, let me know if there's anything obvious I missed, or if you think something in a group belongs elsewhere.