### PR TITLE
Minor apworld update and some fixes.

### DIFF
--- a/apworld/toontown/__init__.py
+++ b/apworld/toontown/__init__.py
@@ -8,10 +8,10 @@ from worlds.generic.Rules import set_rule
 from . import regions, consts
 from .consts import ToontownItem, ToontownLocation, ToontownWinCondition
 from .items import ITEM_DESCRIPTIONS, ITEM_DEFINITIONS, ToontownItemDefinition, get_item_def_from_id, ToontownItemName, \
-    ITEM_NAME_TO_ID, FISHING_LICENSES, TELEPORT_ACCESS_ITEMS, FACILITY_KEY_ITEMS, ITEM_NAME_GROUPS
+    ITEM_NAME_TO_ID, FISHING_LICENSES, TELEPORT_ACCESS_ITEMS, FACILITY_KEY_ITEMS, get_item_groups
 from .locations import LOCATION_DESCRIPTIONS, LOCATION_DEFINITIONS, EVENT_DEFINITIONS, ToontownLocationName, \
     ToontownLocationType, ALL_TASK_LOCATIONS_SPLIT, LOCATION_NAME_TO_ID, ToontownLocationDefinition, \
-    TREASURE_LOCATION_TYPES, BOSS_LOCATION_TYPES
+    TREASURE_LOCATION_TYPES, BOSS_LOCATION_TYPES, get_location_groups
 from .options import ToontownOptions, TPSanity, StartingTaskOption, GagTrainingCheckBehavior, FacilityLocking, toontown_option_groups
 from .regions import REGION_DEFINITIONS, ToontownRegionName
 from .ruledefs import test_location, test_entrance, test_item_location
@@ -50,8 +50,9 @@ class ToontownWorld(World):
     location_name_to_id = LOCATION_NAME_TO_ID
 
     location_descriptions = LOCATION_DESCRIPTIONS
+    location_name_groups = get_location_groups()
     item_descriptions = ITEM_DESCRIPTIONS
-    item_name_groups = ITEM_NAME_GROUPS
+    item_name_groups = get_item_groups()
 
     def __init__(self, world, player):
         super(ToontownWorld, self).__init__(world, player)

--- a/apworld/toontown/__init__.py
+++ b/apworld/toontown/__init__.py
@@ -344,19 +344,6 @@ class ToontownWorld(World):
             for _ in range(4):
                 pool.append(self.create_item(ToontownItemName.FISHING_ROD_UPGRADE.value))
 
-        # Fill the rest of the room with junk.
-        junk: int = len(self.multiworld.get_unfilled_locations(self.player)) - len(pool)
-        if junk < 0:
-            raise Exception(f"[Toontown - {self.multiworld.get_player_name(self.player)}] "
-                            f"Generated with too many items ({-junk}). Please tweak settings.")
-
-        trap: int = round(junk * (self.options.trap_percent / 100))
-        filler: int = junk - trap
-        for i in range(trap):
-            pool.append(self.create_item(self.make_random_trap()))
-        for i in range(filler):
-            pool.append(self.create_item(self.make_random_junk()))
-
         # racing item logic
         item = self.create_item(ToontownItemName.GO_KART.value)
         if self.options.racing_logic.value:
@@ -371,10 +358,24 @@ class ToontownWorld(World):
         else:
             self.multiworld.push_precollected(item)
 
+
+        # Fill the rest of the room with junk.
+        junk: int = len(self.multiworld.get_unfilled_locations(self.player)) - len(pool)
+        if junk < 0:
+            raise Exception(f"[Toontown - {self.multiworld.get_player_name(self.player)}] "
+                            f"Generated with too many items ({-junk}). Please tweak settings.")
+
+        trap: int = round(junk * (self.options.trap_percent / 100))
+        filler: int = junk - trap
+        for i in range(trap):
+            pool.append(self.create_item(self.get_trap_item_name()))
+        for i in range(filler):
+            pool.append(self.create_item(self.get_filler_item_name()))
+
         # Finalize item pool.
         self.multiworld.itempool += pool
 
-    def make_random_trap(self):
+    def get_trap_item_name(self):
         trap_weights = {
             ToontownItemName.UBER_TRAP.value: self.options.uber_trap_weight,
             ToontownItemName.DRIP_TRAP.value: self.options.drip_trap_weight,
@@ -386,7 +387,7 @@ class ToontownWorld(World):
         trap_items = list(trap_weights.keys())
         return random.choices(trap_items, weights=[trap_weights[i] for i in trap_items])[0]
 
-    def make_random_junk(self):
+    def get_filler_item_name(self):
         junk_weights = {
             ToontownItemName.MONEY_150.value: (self.options.bean_weight/4),
             ToontownItemName.MONEY_400.value: (self.options.bean_weight/4),

--- a/apworld/toontown/items.py
+++ b/apworld/toontown/items.py
@@ -258,31 +258,31 @@ ITEM_DESCRIPTIONS = {
 for i in range(len(ITEM_DEFINITIONS)):
     ITEM_DEFINITIONS[i].unique_id = i + consts.BASE_ID
 
-GAG_TRAINING_FRAMES = (
-    ToontownItemName.TOONUP_FRAME,
-    ToontownItemName.TRAP_FRAME,
-    ToontownItemName.LURE_FRAME,
-    ToontownItemName.SOUND_FRAME,
-    ToontownItemName.THROW_FRAME,
-    ToontownItemName.SQUIRT_FRAME,
-    ToontownItemName.DROP_FRAME
-)
+def hood_to_tp_item_name(hoodId: int) -> ToontownItemName:
+    return {
+        2000: ToontownItemName.TTC_ACCESS,
+        1000: ToontownItemName.DD_ACCESS,
+        5000: ToontownItemName.DG_ACCESS,
+        4000: ToontownItemName.MML_ACCESS,
+        3000: ToontownItemName.TB_ACCESS,
+        9000: ToontownItemName.DDL_ACCESS,
+        11000: ToontownItemName.SBHQ_ACCESS,
+        12000: ToontownItemName.CBHQ_ACCESS,
+        13000: ToontownItemName.LBHQ_ACCESS,
+        10000: ToontownItemName.BBHQ_ACCESS,
+        6000: ToontownItemName.AA_ACCESS,
+        17000: ToontownItemName.AA_ACCESS,
+        8000: ToontownItemName.GS_ACCESS,
+    }.get(hoodId)
 
-GAG_UPGRADES = (
-    ToontownItemName.TOONUP_UPGRADE,
-    ToontownItemName.TRAP_UPGRADE,
-    ToontownItemName.LURE_UPGRADE,
-    ToontownItemName.SOUND_UPGRADE,
-    ToontownItemName.THROW_UPGRADE,
-    ToontownItemName.SQUIRT_UPGRADE,
-    ToontownItemName.DROP_UPGRADE
-)
 
-GAG_CAPACITY = (
-    ToontownItemName.GAG_CAPACITY_5,
-    ToontownItemName.GAG_CAPACITY_10,
-    ToontownItemName.GAG_CAPACITY_15
-)
+def get_item_def_from_id(_id: int) -> Optional[ToontownItemDefinition]:
+    index = _id - consts.BASE_ID
+    if 0 <= index < len(ITEM_DEFINITIONS):
+        return ITEM_DEFINITIONS[index]
+    return None
+
+ITEM_NAME_TO_ID = {item.name.value: i + consts.BASE_ID for i, item in enumerate(ITEM_DEFINITIONS)}
 
 FISHING_LICENSES = (
     ToontownItemName.TTC_FISHING,
@@ -323,112 +323,112 @@ FACILITY_KEY_ITEMS = (
     ToontownItemName.BACK_THREE_ACCESS,
 )
 
-LAFF_BOOSTS = (
-    ToontownItemName.LAFF_BOOST_1,
-    ToontownItemName.LAFF_BOOST_2,
-    ToontownItemName.LAFF_BOOST_3,
-    ToontownItemName.LAFF_BOOST_4,
-    ToontownItemName.LAFF_BOOST_5
-)
 
-TRAINING_BOOSTS = (
-    ToontownItemName.GAG_MULTIPLIER_1,
-    ToontownItemName.GAG_MULTIPLIER_2
-)
+def get_item_groups():
+    GAG_TRAINING_FRAMES = (
+        ToontownItemName.TOONUP_FRAME,
+        ToontownItemName.TRAP_FRAME,
+        ToontownItemName.LURE_FRAME,
+        ToontownItemName.SOUND_FRAME,
+        ToontownItemName.THROW_FRAME,
+        ToontownItemName.SQUIRT_FRAME,
+        ToontownItemName.DROP_FRAME
+    )
 
-ACTIVITY_KEYS = (
-    ToontownItemName.GOLF_PUTTER,
-    ToontownItemName.GO_KART
-)
+    GAG_UPGRADES = (
+        ToontownItemName.TOONUP_UPGRADE,
+        ToontownItemName.TRAP_UPGRADE,
+        ToontownItemName.LURE_UPGRADE,
+        ToontownItemName.SOUND_UPGRADE,
+        ToontownItemName.THROW_UPGRADE,
+        ToontownItemName.SQUIRT_UPGRADE,
+        ToontownItemName.DROP_UPGRADE
+    )
 
-REWARD_BUNDLES = (
-    ToontownItemName.SOS_REWARD,
-    ToontownItemName.UNITE_REWARD,
-    ToontownItemName.PINK_SLIP_REWARD
-)
+    GAG_CAPACITY = (
+        ToontownItemName.GAG_CAPACITY_5,
+        ToontownItemName.GAG_CAPACITY_10,
+        ToontownItemName.GAG_CAPACITY_15
+    )
+    
+    LAFF_BOOSTS = (
+        ToontownItemName.LAFF_BOOST_1,
+        ToontownItemName.LAFF_BOOST_2,
+        ToontownItemName.LAFF_BOOST_3,
+        ToontownItemName.LAFF_BOOST_4,
+        ToontownItemName.LAFF_BOOST_5
+    )
 
-TRAPS = (
-    ToontownItemName.DRIP_TRAP,
-    ToontownItemName.UBER_TRAP,
-    ToontownItemName.BEAN_TAX_TRAP_1000,
-    ToontownItemName.BEAN_TAX_TRAP_1250,
-    ToontownItemName.BEAN_TAX_TRAP_750,
-    ToontownItemName.GAG_SHUFFLE_TRAP
-)
+    TRAINING_BOOSTS = (
+        ToontownItemName.GAG_MULTIPLIER_1,
+        ToontownItemName.GAG_MULTIPLIER_2
+    )
 
-COG_DISGUISES = (
-    ToontownItemName.SELLBOT_DISGUISE,
-    ToontownItemName.CASHBOT_DISGUISE,
-    ToontownItemName.LAWBOT_DISGUISE,
-    ToontownItemName.BOSSBOT_DISGUISE
-)
+    ACTIVITY_KEYS = (
+        ToontownItemName.GOLF_PUTTER,
+        ToontownItemName.GO_KART
+    )
 
-GAG_EXP = (
-    ToontownItemName.XP_10,
-    ToontownItemName.XP_15,
-    ToontownItemName.XP_20
-)
+    REWARD_BUNDLES = (
+        ToontownItemName.SOS_REWARD,
+        ToontownItemName.UNITE_REWARD,
+        ToontownItemName.PINK_SLIP_REWARD
+    )
 
-JELLYBEANS = (
-    ToontownItemName.MONEY_150,
-    ToontownItemName.MONEY_400,
-    ToontownItemName.MONEY_700,
-    ToontownItemName.MONEY_1000
-)
+    TRAPS = (
+        ToontownItemName.DRIP_TRAP,
+        ToontownItemName.UBER_TRAP,
+        ToontownItemName.BEAN_TAX_TRAP_1000,
+        ToontownItemName.BEAN_TAX_TRAP_1250,
+        ToontownItemName.BEAN_TAX_TRAP_750,
+        ToontownItemName.GAG_SHUFFLE_TRAP
+    )
 
-JELLYBEAN_CAPACITY = (
-    ToontownItemName.MONEY_CAP_1000,
-)
+    COG_DISGUISES = (
+        ToontownItemName.SELLBOT_DISGUISE,
+        ToontownItemName.CASHBOT_DISGUISE,
+        ToontownItemName.LAWBOT_DISGUISE,
+        ToontownItemName.BOSSBOT_DISGUISE
+    )
 
-TASK_CAPACITY = (
-    ToontownItemName.TASK_CAPACITY,
-)
+    GAG_EXP = (
+        ToontownItemName.XP_10,
+        ToontownItemName.XP_15,
+        ToontownItemName.XP_20
+    )
 
-def hood_to_tp_item_name(hoodId: int) -> ToontownItemName:
-    return {
-        2000: ToontownItemName.TTC_ACCESS,
-        1000: ToontownItemName.DD_ACCESS,
-        5000: ToontownItemName.DG_ACCESS,
-        4000: ToontownItemName.MML_ACCESS,
-        3000: ToontownItemName.TB_ACCESS,
-        9000: ToontownItemName.DDL_ACCESS,
-        11000: ToontownItemName.SBHQ_ACCESS,
-        12000: ToontownItemName.CBHQ_ACCESS,
-        13000: ToontownItemName.LBHQ_ACCESS,
-        10000: ToontownItemName.BBHQ_ACCESS,
-        6000: ToontownItemName.AA_ACCESS,
-        17000: ToontownItemName.AA_ACCESS,
-        8000: ToontownItemName.GS_ACCESS,
-    }.get(hoodId)
+    JELLYBEANS = (
+        ToontownItemName.MONEY_150,
+        ToontownItemName.MONEY_400,
+        ToontownItemName.MONEY_700,
+        ToontownItemName.MONEY_1000
+    )
 
+    JELLYBEAN_CAPACITY = (
+        ToontownItemName.MONEY_CAP_1000,
+    )
 
-def get_item_def_from_id(_id: int) -> Optional[ToontownItemDefinition]:
-    index = _id - consts.BASE_ID
-    if 0 <= index < len(ITEM_DEFINITIONS):
-        return ITEM_DEFINITIONS[index]
-    return None
+    TASK_CAPACITY = (
+        ToontownItemName.TASK_CAPACITY,
+    )
 
+    ITEM_NAME_GROUPS_OBJECT = {
+        "Cog Disguises": COG_DISGUISES,
+        "Facility Keys": FACILITY_KEY_ITEMS,
+        "Access Keys": TELEPORT_ACCESS_ITEMS,
+        "Gag Training Frames": GAG_TRAINING_FRAMES,
+        "Gag Capacity Increase": GAG_CAPACITY,
+        "Gag Training Boosts": TRAINING_BOOSTS,
+        "Gag Upgrades": GAG_UPGRADES,
+        "Fishing Licenses": FISHING_LICENSES,
+        "Jellybean Capacity": JELLYBEAN_CAPACITY,
+        "Side Activity Keys": ACTIVITY_KEYS,
+        "Task Capacity": TASK_CAPACITY,
+        "Laff Boosts": LAFF_BOOSTS,
+        "Reward Bundles": REWARD_BUNDLES,
+        "Jellybeans": JELLYBEANS,
+        "Gag Exp Reward": GAG_EXP,
+        "Traps": TRAPS,
+    }
 
-ITEM_NAME_TO_ID = {item.name.value: i + consts.BASE_ID for i, item in enumerate(ITEM_DEFINITIONS)}
-
-
-ITEM_NAME_GROUPS_OBJECT = {
-    "Cog Disguises": COG_DISGUISES,
-    "Facility Keys": FACILITY_KEY_ITEMS,
-    "Access Keys": TELEPORT_ACCESS_ITEMS,
-    "Gag Training Frames": GAG_TRAINING_FRAMES,
-    "Gag Capacity Increase": GAG_CAPACITY,
-    "Gag Training Boosts": TRAINING_BOOSTS,
-    "Gag Upgrades": GAG_UPGRADES,
-    "Fishing Licenses": FISHING_LICENSES,
-    "Jellybean Capacity": JELLYBEAN_CAPACITY,
-    "Side Activity Keys": ACTIVITY_KEYS,
-    "Task Capacity": TASK_CAPACITY,
-    "Laff Boosts": LAFF_BOOSTS,
-    "Reward Bundles": REWARD_BUNDLES,
-    "Jellybeans": JELLYBEANS,
-    "Gag Exp Reward": GAG_EXP,
-    "Traps": TRAPS,
-}
-
-ITEM_NAME_GROUPS = {k:[i.value for i in v] for k,v in ITEM_NAME_GROUPS_OBJECT.items()}
+    return {k:[i.value for i in v] for k,v in ITEM_NAME_GROUPS_OBJECT.items()}

--- a/apworld/toontown/items.py
+++ b/apworld/toontown/items.py
@@ -323,27 +323,28 @@ FACILITY_KEY_ITEMS = (
     ToontownItemName.BACK_THREE_ACCESS,
 )
 
-
+GAG_TRAINING_FRAMES = (
+    ToontownItemName.TOONUP_FRAME,
+    ToontownItemName.TRAP_FRAME,
+    ToontownItemName.LURE_FRAME,
+    ToontownItemName.SOUND_FRAME,
+    ToontownItemName.THROW_FRAME,
+    ToontownItemName.SQUIRT_FRAME,
+    ToontownItemName.DROP_FRAME
+)
+GAG_UPGRADES = (
+    ToontownItemName.TOONUP_UPGRADE,
+    ToontownItemName.TRAP_UPGRADE,
+    ToontownItemName.LURE_UPGRADE,
+    ToontownItemName.SOUND_UPGRADE,
+    ToontownItemName.THROW_UPGRADE,
+    ToontownItemName.SQUIRT_UPGRADE,
+    ToontownItemName.DROP_UPGRADE
+)
 def get_item_groups():
-    GAG_TRAINING_FRAMES = (
-        ToontownItemName.TOONUP_FRAME,
-        ToontownItemName.TRAP_FRAME,
-        ToontownItemName.LURE_FRAME,
-        ToontownItemName.SOUND_FRAME,
-        ToontownItemName.THROW_FRAME,
-        ToontownItemName.SQUIRT_FRAME,
-        ToontownItemName.DROP_FRAME
-    )
 
-    GAG_UPGRADES = (
-        ToontownItemName.TOONUP_UPGRADE,
-        ToontownItemName.TRAP_UPGRADE,
-        ToontownItemName.LURE_UPGRADE,
-        ToontownItemName.SOUND_UPGRADE,
-        ToontownItemName.THROW_UPGRADE,
-        ToontownItemName.SQUIRT_UPGRADE,
-        ToontownItemName.DROP_UPGRADE
-    )
+
+    
 
     GAG_CAPACITY = (
         ToontownItemName.GAG_CAPACITY_5,

--- a/apworld/toontown/locations.py
+++ b/apworld/toontown/locations.py
@@ -1190,3 +1190,33 @@ LOCATION_ID_TO_NAME = {i + consts.BASE_ID: location.name.value for i, location i
 
 def get_location_def_from_name(name: ToontownLocationName) -> ToontownLocationDefinition:
     return LOCATION_NAME_TO_DEFINITION[name]
+
+def get_location_groups():
+    return {
+    "All Tasks": [name.value for name in ALL_TASK_LOCATIONS],
+    "Fishing": [loc_def.name.value for loc_def in LOCATION_DEFINITIONS if loc_def.region == ToontownRegionName.FISHING],
+    "Pet Shops": [name.value for name in SHOP_LOCATIONS],
+    "Gag Training": [loc_def.name.value for loc_def in LOCATION_DEFINITIONS if loc_def.region == ToontownRegionName.TRAINING],
+    "Cog Gallery": [loc_def.name.value for loc_def in LOCATION_DEFINITIONS if loc_def.region == ToontownRegionName.GALLERY],
+    "Treasures": [loc_def.name.value for loc_def in TREASURE_LOCATION_DEFINITIONS],
+    "Boss Clears": [loc_def.name.value for loc_def in BOSS_LOCATION_DEFINITIONS],
+    "Toontown Central": [loc_def.name.value for loc_def in LOCATION_DEFINITIONS if loc_def.region == ToontownRegionName.TTC],
+    "Donald's Dock": [loc_def.name.value for loc_def in LOCATION_DEFINITIONS if loc_def.region == ToontownRegionName.DD],
+    "Daisy Gardens": [loc_def.name.value for loc_def in LOCATION_DEFINITIONS if loc_def.region == ToontownRegionName.DG],
+    "Minnie's Melodyland": [loc_def.name.value for loc_def in LOCATION_DEFINITIONS if loc_def.region == ToontownRegionName.MML],
+    "The Brrrgh": [loc_def.name.value for loc_def in LOCATION_DEFINITIONS if loc_def.region == ToontownRegionName.TB],
+    "Donald's Dreamland": [loc_def.name.value for loc_def in LOCATION_DEFINITIONS if loc_def.region == ToontownRegionName.DDL],
+    "Goofy Speedway": [loc_def.name.value for loc_def in LOCATION_DEFINITIONS if loc_def.region == ToontownRegionName.GS],
+    "Acorn Acres": [loc_def.name.value for loc_def in LOCATION_DEFINITIONS if loc_def.region == ToontownRegionName.AA],
+    "Sellbot HQ": [loc_def.name.value for loc_def in LOCATION_DEFINITIONS if loc_def.region == ToontownRegionName.SBHQ],
+    "SBHQ Facilities": [loc_def.name.value for loc_def in LOCATION_DEFINITIONS if loc_def.type == ToontownLocationType.FACILITIES and loc_def.region == ToontownRegionName.SBHQ],
+    "Cashbot HQ": [loc_def.name.value for loc_def in LOCATION_DEFINITIONS if loc_def.region == ToontownRegionName.CBHQ],
+    "CBHQ Facilities": [loc_def.name.value for loc_def in LOCATION_DEFINITIONS if loc_def.type == ToontownLocationType.FACILITIES and loc_def.region == ToontownRegionName.CBHQ],
+    "Lawbot HQ": [loc_def.name.value for loc_def in LOCATION_DEFINITIONS if loc_def.region == ToontownRegionName.LBHQ],
+    "LBHQ Facilities": [loc_def.name.value for loc_def in LOCATION_DEFINITIONS if loc_def.type == ToontownLocationType.FACILITIES and loc_def.region == ToontownRegionName.LBHQ],
+    "Bossbot HQ": [loc_def.name.value for loc_def in LOCATION_DEFINITIONS if loc_def.region == ToontownRegionName.BBHQ],
+    "BBHQ Facilities": [loc_def.name.value for loc_def in LOCATION_DEFINITIONS if loc_def.type == ToontownLocationType.FACILITIES and loc_def.region == ToontownRegionName.BBHQ],
+    "Buildings": [loc_def.name.value for loc_def in LOCATION_DEFINITIONS if loc_def.region == ToontownRegionName.BUILDINGS],
+    "Golfing": [loc_def.name.value for loc_def in LOCATION_DEFINITIONS if loc_def.type == ToontownLocationType.GOLF],
+    "Racing": [loc_def.name.value for loc_def in LOCATION_DEFINITIONS if loc_def.type == ToontownLocationType.RACING],
+    }

--- a/apworld/toontown/ruledefs.py
+++ b/apworld/toontown/ruledefs.py
@@ -250,7 +250,7 @@ def FishCatch(state: CollectionState, locentr: LocEntrDef, world: MultiWorld, pl
 
     # Get our rod tier.
     hasMaxRod = fishProgression not in (FishProgression.Rods, FishProgression.LicensesAndRods)
-    rodTier = 4 if hasMaxRod else state.count(ToontownItemName.FISHING_ROD_UPGRADE.value, player)
+    rodTier = 4 if hasMaxRod else min(state.count(ToontownItemName.FISHING_ROD_UPGRADE.value, player), 4)
     needsLicense = fishProgression in (FishProgression.Licenses, FishProgression.LicensesAndRods)
     hasAnyLicense = True
 

--- a/toontown/archipelago/util/win_condition.py
+++ b/toontown/archipelago/util/win_condition.py
@@ -130,7 +130,9 @@ class HoodTaskWinCondition(WinCondition):
         locations = set(self.toon.getCheckedLocations())
 
         # Then construct a mapping of how many quests were completed per hood
-        completion_per_hood: dict[int, int] = {hood_id: locations.intersection(task.unique_id for task in tasks)
+        completion_per_hood: dict[int, int] = {hood_id: len(locations.intersection(
+                                                   task.unique_id for task in LOCATION_DEFINITIONS 
+                                                   if task.name in tasks))
                                                for hood_id, tasks in self.TASKING_HOODS.items()}
 
         return completion_per_hood

--- a/toontown/toon/DistributedToonAI.py
+++ b/toontown/toon/DistributedToonAI.py
@@ -4756,13 +4756,13 @@ class DistributedToonAI(DistributedPlayerAI.DistributedPlayerAI, DistributedSmoo
     # Generally called by addMoney
     def ap_addMoney(self, money):
         self.notify.debug(f"increasing AP jellybeans for {self.getDoId()} by: {money}" )
-        ops = [("add", money), ("min", self.getMaxMoney())] # Keep stored money below max.
+        ops = [("default", True), ("add", money), ("min", self.getMaxMoney())] # Keep stored money below max.
         self.apply_to_ap_data("jellybeans", ops, True, default=self.slotData.get('starting_money', 50))
 
     # Generally called by takeMoney
     def ap_takeMoney(self, money):
         self.notify.debug(f"decreasing AP jellybeans for {self.getDoId()} by: {money}" )
-        ops = [("add", -money), ("max", 0)] # Keep stored money above 0
+        ops = [("default", True), ("add", -money), ("max", 0)] # Keep stored money above 0
         self.apply_to_ap_data("jellybeans", ops, True, default=self.slotData.get('starting_money', 50))
 
     # Mirrors Experience.addExp


### PR DESCRIPTION
* 2 extra items are generated because Golf Putter and Go Kart was being generated after we generated junk.
* Tasks when using multiple toons don't both count towards the win condition. (or tasks completed by someone else using `!collect`)
* Jellybeans weren't actually defaulting to the value set in the yaml, on archipelago's side.

additionally, an apworld issue happened in generation with our ruledefs:
* EarthBound checks our rules for some reason, and passes what is likely a malformed CollectionState with, presumably all the fishing rods for the entire multiworld in one player.
This might be possible to happen with just toontown if a fishing rod is in start_inventory, but I haven't tested that and fixed this specifically for the async happening later.


Someone else decide for the conflict, it was fixed in the time while I was working on the rest of the fixes before pushing.