### PR TITLE
Win condition, Performance and Tracker improvements.

### DIFF
--- a/apworld/EXAMPLE_TOONTOWN.yaml
+++ b/apworld/EXAMPLE_TOONTOWN.yaml
@@ -4,7 +4,7 @@ name: Colorful Toon
 
 Toontown:
   progression_balancing: 50
-  accessibility: locations
+  accessibility: full
 
   ### Team Settings ###
 
@@ -274,5 +274,5 @@ Toontown:
 
 game: Toontown
 requires:
-  version: 0.4.4
+  version: 0.5.1
 description: 'Default Toontown Template'

--- a/apworld/toontown/__init__.py
+++ b/apworld/toontown/__init__.py
@@ -153,6 +153,10 @@ class ToontownWorld(World):
                 if location_data.type == ToontownLocationType.GALLERY_MAX:
                     location.progress_type = LocationProgressType.EXCLUDED
 
+            if self.options.cog_bosses_required.value and self.options.checks_per_boss.value < 1:
+                if location_data.type in locations.BOSS_LOCATION_TYPES:
+                    location.progress_type = LocationProgressType.EXCLUDED
+
         for i, location_data in enumerate(EVENT_DEFINITIONS):
             region = regions[location_data.region]
             location = ToontownLocation(player, location_data.name.value, None, region)
@@ -547,6 +551,8 @@ class ToontownWorld(World):
 
         cpb = self.options.checks_per_boss.value
         rev_locs = BOSS_LOCATION_TYPES[::-1]
+        if self.options.cog_bosses_required.value and cpb < 1:
+            cpb = 1
         for i in range(len(rev_locs) - cpb):
             forbidden_location_types.add(rev_locs[i])
 

--- a/apworld/toontown/__init__.py
+++ b/apworld/toontown/__init__.py
@@ -11,7 +11,7 @@ from .items import ITEM_DESCRIPTIONS, ITEM_DEFINITIONS, ToontownItemDefinition, 
     ITEM_NAME_TO_ID, FISHING_LICENSES, TELEPORT_ACCESS_ITEMS, FACILITY_KEY_ITEMS, get_item_groups
 from .locations import LOCATION_DESCRIPTIONS, LOCATION_DEFINITIONS, EVENT_DEFINITIONS, ToontownLocationName, \
     ToontownLocationType, ALL_TASK_LOCATIONS_SPLIT, LOCATION_NAME_TO_ID, ToontownLocationDefinition, \
-    TREASURE_LOCATION_TYPES, BOSS_LOCATION_TYPES, get_location_groups
+    TREASURE_LOCATION_TYPES, BOSS_LOCATION_TYPES, BOSS_EVENT_DEFINITIONS, get_location_groups
 from .options import ToontownOptions, TPSanity, StartingTaskOption, GagTrainingCheckBehavior, FacilityLocking, toontown_option_groups
 from .regions import REGION_DEFINITIONS, ToontownRegionName
 from .ruledefs import test_location, test_entrance, test_item_location
@@ -130,6 +130,7 @@ class ToontownWorld(World):
         # Determine forbidden location types.
         forbidden_location_types: set[ToontownLocationType] = self.get_disabled_location_types()
 
+
         # Now create locations.
         for i, location_data in enumerate(LOCATION_DEFINITIONS):
             # Do we skip this location generation?
@@ -153,11 +154,7 @@ class ToontownWorld(World):
                 if location_data.type == ToontownLocationType.GALLERY_MAX:
                     location.progress_type = LocationProgressType.EXCLUDED
 
-            if self.options.cog_bosses_required.value and self.options.checks_per_boss.value < 1:
-                if location_data.type in locations.BOSS_LOCATION_TYPES:
-                    location.progress_type = LocationProgressType.EXCLUDED
-
-        for i, location_data in enumerate(EVENT_DEFINITIONS):
+        for location_data in EVENT_DEFINITIONS:
             region = regions[location_data.region]
             location = ToontownLocation(player, location_data.name.value, None, region)
             region.locations.append(location)
@@ -169,10 +166,20 @@ class ToontownWorld(World):
             else:
                 location.place_locked_item(self.create_event(location_data.name.value))
 
+
+
         # Force various item placements.
         self._force_item_placement(ToontownLocationName.STARTING_NEW_GAME,  ToontownItemName.TTC_ACCESS)
         self._force_item_placement(ToontownLocationName.STARTING_TRACK_ONE, self.first_track)
         self._force_item_placement(ToontownLocationName.STARTING_TRACK_TWO, self.second_track)
+
+        # only populate these locations if there's a reason to go there.
+        if self.options.checks_per_boss.value > 0 or self.options.win_condition_cog_bosses.value:
+            self._force_item_placement(ToontownLocationName.FIGHT_VP,  ToontownItemName.VP)
+            self._force_item_placement(ToontownLocationName.FIGHT_CFO,  ToontownItemName.CFO)
+            self._force_item_placement(ToontownLocationName.FIGHT_CJ,  ToontownItemName.CJ)
+            self._force_item_placement(ToontownLocationName.FIGHT_CEO,  ToontownItemName.CEO)
+
 
         # Do we have force teleport access? if so place our tps
         if self.options.tpsanity.value == TPSanity.option_treasure:
@@ -551,8 +558,6 @@ class ToontownWorld(World):
 
         cpb = self.options.checks_per_boss.value
         rev_locs = BOSS_LOCATION_TYPES[::-1]
-        if self.options.cog_bosses_required.value and cpb < 1:
-            cpb = 1
         for i in range(len(rev_locs) - cpb):
             forbidden_location_types.add(rev_locs[i])
 

--- a/apworld/toontown/__init__.py
+++ b/apworld/toontown/__init__.py
@@ -560,6 +560,9 @@ class ToontownWorld(World):
         rev_locs = BOSS_LOCATION_TYPES[::-1]
         for i in range(len(rev_locs) - cpb):
             forbidden_location_types.add(rev_locs[i])
+        wcb = self.options.win_condition_cog_bosses.value
+        if cpb <= 0 and not wcb:
+            forbidden_location_types.add(ToontownLocationType.BOSS_META)
 
         racing = self.options.racing_logic.value
         if not racing:

--- a/apworld/toontown/items.py
+++ b/apworld/toontown/items.py
@@ -125,6 +125,12 @@ class ToontownItemName(enum.Enum):
     DRIP_TRAP = "Drip Trap"
     GAG_SHUFFLE_TRAP = "Gag Shuffle Trap"
 
+    ### META ###
+    VP = "Defeated Sellbot VP"
+    CFO = "Defeated Cashbot CFO"
+    CJ = "Defeated Lawbot CJ"
+    CEO =  "Defeated Bossbot CEO"
+
 
 @dataclass
 class ToontownItemDefinition:
@@ -245,6 +251,12 @@ ITEM_DEFINITIONS: List[ToontownItemDefinition] = [
     ToontownItemDefinition(ToontownItemName.DRIP_TRAP,             ItemClassification.trap),
     ToontownItemDefinition(ToontownItemName.GAG_SHUFFLE_TRAP,      ItemClassification.trap),
     # endregion
+    # region BossDefeatItems
+    ToontownItemDefinition(ToontownItemName.VP,                   ItemClassification.progression_skip_balancing),
+    ToontownItemDefinition(ToontownItemName.CFO,                   ItemClassification.progression_skip_balancing),
+    ToontownItemDefinition(ToontownItemName.CJ,                   ItemClassification.progression_skip_balancing),
+    ToontownItemDefinition(ToontownItemName.CEO,                   ItemClassification.progression_skip_balancing),
+    # endregion
 ]
 
 ITEM_DESCRIPTIONS = {
@@ -252,6 +264,10 @@ ITEM_DESCRIPTIONS = {
     ToontownItemName.CASHBOT_DISGUISE.value: "Grants access to fight the Cashbot CFO",
     ToontownItemName.LAWBOT_DISGUISE.value:  "Grants access to fight the Lawbot CJ",
     ToontownItemName.BOSSBOT_DISGUISE.value: "Grants access to fight the Bossbot CEO",
+    ToontownItemName.VP: "Rewarded for defeating the Sellbot VP", 
+    ToontownItemName.CFO: "Rewarded for defeating the Cashbot CFO",
+    ToontownItemName.CJ: "Rewarded for defeating the Lawbot CJ", 
+    ToontownItemName.CEO: "Rewarded for defeating the Bossbot CEO",
 }
 
 

--- a/apworld/toontown/locations.py
+++ b/apworld/toontown/locations.py
@@ -472,27 +472,32 @@ class ToontownLocationName(Enum):
     BACK_THREE_BARREL_5 =                       "Back Three Golfing Barrel (Hole 2)"
     BACK_THREE_BARREL_6 =                       "Back Three Golfing Barrel (Hole 3)"
     CLEAR_BACK_THREE =                          "Back Three Cleared"
+    FIGHT_VP =                                  "Sellbot VP"
     SELLBOT_PROOF_1 =                           "Sellbot Proof Bundle 1"
     SELLBOT_PROOF_2 =                           "Sellbot Proof Bundle 2"
     SELLBOT_PROOF_3 =                           "Sellbot Proof Bundle 3"
     SELLBOT_PROOF_4 =                           "Sellbot Proof Bundle 4"
     SELLBOT_PROOF_5 =                           "Sellbot Proof Bundle 5"
+    FIGHT_CFO =                                 "Cashbot CFO"
     CASHBOT_PROOF_1 =                           "Cashbot Proof Bundle 1"
     CASHBOT_PROOF_2 =                           "Cashbot Proof Bundle 2"
     CASHBOT_PROOF_3 =                           "Cashbot Proof Bundle 3"
     CASHBOT_PROOF_4 =                           "Cashbot Proof Bundle 4"
     CASHBOT_PROOF_5 =                           "Cashbot Proof Bundle 5"
+    FIGHT_CJ =                                  "Lawbot CJ"
     LAWBOT_PROOF_1 =                            "Lawbot Proof Bundle 1"
     LAWBOT_PROOF_2 =                            "Lawbot Proof Bundle 2"
     LAWBOT_PROOF_3 =                            "Lawbot Proof Bundle 3"
     LAWBOT_PROOF_4 =                            "Lawbot Proof Bundle 4"
     LAWBOT_PROOF_5 =                            "Lawbot Proof Bundle 5"
+    FIGHT_CEO =                                 "Bossbot CEO"
     BOSSBOT_PROOF_1 =                           "Bossbot Proof Bundle 1"
     BOSSBOT_PROOF_2 =                           "Bossbot Proof Bundle 2"
     BOSSBOT_PROOF_3 =                           "Bossbot Proof Bundle 3"
     BOSSBOT_PROOF_4 =                           "Bossbot Proof Bundle 4"
     BOSSBOT_PROOF_5 =                           "Bossbot Proof Bundle 5"
     SAVED_TOONTOWN =                            "Save Toontown"
+
 
 
 class ToontownLocationType(IntEnum):
@@ -707,6 +712,13 @@ REGION_TO_BOSS_LOCATIONS: dict[ToontownRegionName, list[ToontownLocationName]] =
     ],
 }
 
+REGION_TO_BOSS_EVENTS: dict[ToontownRegionName, list[ToontownLocationName]] = {
+    ToontownRegionName.SBHQ: ToontownLocationName.FIGHT_VP,
+    ToontownRegionName.CBHQ: ToontownLocationName.FIGHT_CFO,
+    ToontownRegionName.LBHQ: ToontownLocationName.FIGHT_CJ,
+    ToontownRegionName.BBHQ: ToontownLocationName.FIGHT_CEO,
+}
+
 BOSS_LOCATION_TYPES: list[ToontownLocationType] = [
     ToontownLocationType.BOSSES_1,
     ToontownLocationType.BOSSES_2,
@@ -716,18 +728,23 @@ BOSS_LOCATION_TYPES: list[ToontownLocationType] = [
 ]
 
 REGION_TO_BOSS_RULES: dict[ToontownRegionName, list[list]] = {
-    ToontownRegionName.SBHQ: [[Rule.CanFightVP], [Rule.CanFightVP], [Rule.CanFightVP], [Rule.CanFightVP], [Rule.CanFightVP]],
-    ToontownRegionName.CBHQ: [[Rule.CanFightCFO], [Rule.CanFightCFO], [Rule.CanFightCFO], [Rule.CanFightCFO], [Rule.CanFightCFO]],
-    ToontownRegionName.LBHQ: [[Rule.CanFightCJ], [Rule.CanFightCJ], [Rule.CanFightCJ], [Rule.CanFightCJ], [Rule.CanFightCJ]],
-    ToontownRegionName.BBHQ: [[Rule.CanFightCEO], [Rule.CanFightCEO], [Rule.CanFightCEO], [Rule.CanFightCEO], [Rule.CanFightCEO]]
+    ToontownRegionName.SBHQ: [Rule.CanFightVP],
+    ToontownRegionName.CBHQ: [Rule.CanFightCFO],
+    ToontownRegionName.LBHQ: [Rule.CanFightCJ],
+    ToontownRegionName.BBHQ: [Rule.CanFightCEO],
 }
 
 BOSS_LOCATION_DEFINITIONS: List[ToontownLocationDefinition] = [
     ToontownLocationDefinition(location_name,  location_type, region_name, rule_set, [ItemRule.RestrictDisguises])
-    for region_name in REGION_TO_BOSS_LOCATIONS.keys()
+    for region_name, locations in REGION_TO_BOSS_LOCATIONS.items()
     for location_name, location_type, rule_set in zip(
-        REGION_TO_BOSS_LOCATIONS.get(region_name), BOSS_LOCATION_TYPES, REGION_TO_BOSS_RULES.get(region_name)
+        locations, BOSS_LOCATION_TYPES, [REGION_TO_BOSS_RULES.get(region_name)] * len(BOSS_LOCATION_TYPES)
     )
+]
+
+BOSS_EVENT_DEFINITIONS: List[ToontownLocationDefinition] = [
+    ToontownLocationDefinition(location_name,  ToontownLocationType.MISC, region_name, REGION_TO_BOSS_RULES.get(region_name), [ItemRule.RestrictDisguises])
+    for region_name, location_name in REGION_TO_BOSS_EVENTS.items()
 ]
 # endregion
 
@@ -1146,7 +1163,7 @@ LOCATION_DEFINITIONS: List[ToontownLocationDefinition] = [
     ToontownLocationDefinition(ToontownLocationName.DROP_PIANO_UNLOCKED,          ToontownLocationType.GAG_TRAINING, ToontownRegionName.TRAINING, [Rule.DropSix]),
     ToontownLocationDefinition(ToontownLocationName.DROP_BOAT_UNLOCKED,           ToontownLocationType.GAG_TRAINING, ToontownRegionName.TRAINING, [Rule.DropSeven]),
     # endregion
-    ] + BOSS_LOCATION_DEFINITIONS
+    ] + BOSS_LOCATION_DEFINITIONS + BOSS_EVENT_DEFINITIONS
 
 LOCATION_NAME_TO_DEFINITION: dict[ToontownLocationName, ToontownLocationDefinition] = {
     locdef.name: locdef for locdef in LOCATION_DEFINITIONS
@@ -1155,7 +1172,6 @@ LOCATION_NAME_TO_DEFINITION: dict[ToontownLocationName, ToontownLocationDefiniti
 EVENT_DEFINITIONS: List[ToontownLocationDefinition] = [
     ToontownLocationDefinition(ToontownLocationName.SAVED_TOONTOWN, ToontownLocationType.MISC, ToontownRegionName.TTC, [Rule.CanWinGame]),
 ]
-
 
 for i in range(len(LOCATION_DEFINITIONS)):
     LOCATION_DEFINITIONS[i].unique_id = i + consts.BASE_ID

--- a/apworld/toontown/locations.py
+++ b/apworld/toontown/locations.py
@@ -506,6 +506,7 @@ class ToontownLocationType(IntEnum):
     GALLERY_MAX     = auto()  # Locations for maxing cogs in the gallery
     FACILITIES      = auto()  # Locations for clearing facilities
     BUILDINGS       = auto()  # Locations for clearing cog buildings
+    BOSS_META       = auto()  # Locations for clearing bosses
     BOSSES_1        = auto()  # Locations for clearing bosses
     BOSSES_2        = auto()  # Locations for clearing bosses
     BOSSES_3        = auto()  # Locations for clearing bosses
@@ -530,6 +531,7 @@ class ToontownLocationType(IntEnum):
     MML_TASKS       = auto()  # Locations for MML tasks
     TB_TASKS        = auto()  # Locations for TB tasks
     DDL_TASKS       = auto()  # Locations for DDL tasks
+
 
     MISC = auto()
 
@@ -743,7 +745,7 @@ BOSS_LOCATION_DEFINITIONS: List[ToontownLocationDefinition] = [
 ]
 
 BOSS_EVENT_DEFINITIONS: List[ToontownLocationDefinition] = [
-    ToontownLocationDefinition(location_name,  ToontownLocationType.MISC, region_name, REGION_TO_BOSS_RULES.get(region_name), [ItemRule.RestrictDisguises])
+    ToontownLocationDefinition(location_name,  ToontownLocationType.BOSS_META, region_name, REGION_TO_BOSS_RULES.get(region_name), [ItemRule.RestrictDisguises])
     for region_name, location_name in REGION_TO_BOSS_EVENTS.items()
 ]
 # endregion
@@ -1197,6 +1199,10 @@ ALL_TASK_LOCATIONS = (
     TTC_TASK_LOCATIONS + DD_TASK_LOCATIONS + DG_TASK_LOCATIONS
     + MML_TASK_LOCATIONS + TB_TASK_LOCATIONS + DDL_TASK_LOCATIONS
 )
+TASK_LOCATION_TYPES = [
+    ToontownLocationType.TTC_TASKS, ToontownLocationType.DD_TASKS, ToontownLocationType.DG_TASKS,
+    ToontownLocationType.MML_TASKS, ToontownLocationType.TB_TASKS, ToontownLocationType.DDL_TASKS
+]
 
 SCOUTING_REQUIRED_LOCATIONS = ALL_TASK_LOCATIONS.copy() + SHOP_LOCATIONS.copy()
 

--- a/toontown/archipelago/packets/clientbound/connected_packet.py
+++ b/toontown/archipelago/packets/clientbound/connected_packet.py
@@ -194,9 +194,7 @@ class ConnectedPacket(ClientBoundPacketBase):
         new_game = ap_location_name_to_id(locations.ToontownLocationName.STARTING_NEW_GAME.value)
         track_one_check = ap_location_name_to_id(locations.ToontownLocationName.STARTING_TRACK_ONE.value)
         track_two_check = ap_location_name_to_id(locations.ToontownLocationName.STARTING_TRACK_TWO.value)
-        client.av.addCheckedLocation(new_game)
-        client.av.addCheckedLocation(track_one_check)
-        client.av.addCheckedLocation(track_two_check)
+        client.av.addCheckedLocations([new_game, track_one_check, track_two_check])
 
         # Checks Page Variables
         client.av.hintPoints = self.hint_points

--- a/toontown/archipelago/packets/clientbound/received_items_packet.py
+++ b/toontown/archipelago/packets/clientbound/received_items_packet.py
@@ -19,11 +19,8 @@ class ReceivedItemsPacket(ClientBoundPacketBase):
 
     def handle(self, client):
 
-        av_indeces_already_received = []
-        items_received: List[Tuple[int, int]] = client.av.getReceivedItems().copy()
-        for item in items_received:
-            index_received, item_id = item
-            av_indeces_already_received.append(index_received)
+        items_received: List[Tuple[int, int]] = client.av.getReceivedItems()
+        av_indeces_already_received = set(item[0] for item in items_received)
 
         new_items: List[Tuple[int, int]] = []
 

--- a/toontown/archipelago/util/win_condition.py
+++ b/toontown/archipelago/util/win_condition.py
@@ -63,18 +63,16 @@ class InvalidWinCondition(WinCondition):
 
 # Represents the win condition on defeating a certain number of bosses
 class BossDefeatWinCondition(WinCondition):
-    # TODO: change this to check AP boss rewards
+    boss_locations = {locations.LOCATION_NAME_TO_ID.get(loc.name.value) 
+            for loc in locations.BOSS_LOCATION_DEFINITIONS 
+            if loc.name.value.endswith("1")}
+    
     def __init__(self, toon: DistributedToon | DistributedToonAI):
         super().__init__(toon)
         self.bosses_required: int = toon.slotData.get('cog_bosses_required', 4)
 
     def __get_bosses_defeated(self) -> int:
-        bosses = 0
-        for level in self.toon.getCogLevels():
-            if level > 0:
-                bosses += 1
-
-        return bosses
+        return len(self.boss_locations.intersection(self.toon.getCheckedLocations()))
 
     def __get_bosses_needed(self) -> int:
         return max(0, self.bosses_required - self.__get_bosses_defeated())

--- a/toontown/archipelago/util/win_condition.py
+++ b/toontown/archipelago/util/win_condition.py
@@ -123,13 +123,12 @@ class HoodTaskWinCondition(WinCondition):
         ToontownGlobals.TheBrrrgh: TTLocalizer.lTheBrrrgh,
         ToontownGlobals.DonaldsDreamland: TTLocalizer.lDonaldsDreamland,
     }
-    base_dict = {
-        hood_id:0 for hood_id in hood_id_to_name
-    }
+    
 
     def __init__(self, toon: DistributedToon | DistributedToonAI):
         super().__init__(toon)
-        self.tasks_per_hood_needed: int = toon.slotData.get('hood_tasks_required', 12)
+        self.tasks_per_hood_needed: int = toon.slotData.get('hood_tasks_required', 12) 
+        self.checked_per_hood = {hood_id:0 for hood_id in self.hood_id_to_name}
 
     # Calculate a dictionary that represents tasks completed per hood
     # It will always be populated with every hood where tasks may be completed even if no tasks have been completed
@@ -138,10 +137,9 @@ class HoodTaskWinCondition(WinCondition):
         checked = self.toon.getCheckedLocations()
         tasks_checked = self.task_locations.intersection(checked)
         reward_IDs_checked = (Quests.getRewardIdFromAPLocationName(locations.LOCATION_ID_TO_NAME.get(task)) for task in tasks_checked)
-        # Then return a mapping of how many quests were completed per hood.
-        completed = self.base_dict.copy()
-        completed.update(Counter(Quests.getHoodFromRewardId(reward) for reward in reward_IDs_checked))
-        return completed
+        # update and return the mapping of how many quests were completed per hood.
+        self.checked_per_hood.update(Counter(Quests.getHoodFromRewardId(reward) for reward in reward_IDs_checked))
+        return self.checked_per_hood
 
     # Returns the # of tasks completed based on hood with least amount of task progress based on quests completed
     # If all playgrounds have 5 tasks completed except for one which only has 3, we return 3.

--- a/toontown/archipelago/util/win_condition.py
+++ b/toontown/archipelago/util/win_condition.py
@@ -88,15 +88,14 @@ class BossDefeatWinCondition(WinCondition):
 
 
 class GlobalTaskWinCondition(WinCondition):
+    task_locations = {locations.LOCATION_NAME_TO_ID.get(loc.name.value) for loc in locations.ALL_TASK_LOCATIONS}
     def __init__(self, toon: DistributedToon | DistributedToonAI):
         super().__init__(toon)
         self.tasks_required: int = toon.slotData.get('total_tasks_required', 72)
 
     def __get_tasks_completed(self) -> int:
-        # Convert our checked locations into AP names
-        checked = set(locations.LOCATION_ID_TO_NAME.get(loc_id) for loc_id in self.toon.getCheckedLocations())
         # Return the length of our checks filtered by all tasks.
-        return len(checked.intersection(loc_name.value for loc_name in locations.ALL_TASK_LOCATIONS))
+        return len(self.task_locations.intersection(self.toon.getCheckedLocations()))
 
     # Calculate how many tasks are needed to satisfy the win condition
     def __get_tasks_needed(self) -> int:
@@ -113,6 +112,7 @@ class GlobalTaskWinCondition(WinCondition):
 
 
 class HoodTaskWinCondition(WinCondition):
+    task_locations = {locations.LOCATION_NAME_TO_ID.get(loc.name.value) for loc in locations.ALL_TASK_LOCATIONS}
     hood_id_to_name = {
         ToontownGlobals.ToontownCentral: TTLocalizer.lToontownCentral,
         ToontownGlobals.DonaldsDock: TTLocalizer.lDonaldsDock,
@@ -130,11 +130,11 @@ class HoodTaskWinCondition(WinCondition):
     # It will always be populated with every hood where tasks may be completed even if no tasks have been completed
     def __get_tasks_completed(self) -> dict[int, int]:
         # Convert our checked locations into AP names
-        checked = set(locations.LOCATION_ID_TO_NAME.get(loc_id) for loc_id in self.toon.getCheckedLocations())
+        checked = self.toon.getCheckedLocations()
         # Filter that to only tasks.
-        checked.intersection_update(loc_name.value for loc_name in locations.ALL_TASK_LOCATIONS)
+        checked = self.task_locations.intersection(checked)
         # Then construct a mapping of how many quests were completed per hood.
-        return Counter(Quests.getHoodFromRewardId(Quests.getRewardIdFromAPLocationName(task)) for task in checked)
+        return Counter(Quests.getHoodFromRewardId(Quests.getRewardIdFromAPLocationName(locations.LOCATION_ID_TO_NAME.get(task))) for task in checked)
 
     # Returns the # of tasks completed based on hood with least amount of task progress based on quests completed
     # If all playgrounds have 5 tasks completed except for one which only has 3, we return 3.

--- a/toontown/archipelago/util/win_condition.py
+++ b/toontown/archipelago/util/win_condition.py
@@ -63,11 +63,10 @@ class InvalidWinCondition(WinCondition):
 
 # Represents the win condition on defeating a certain number of bosses
 class BossDefeatWinCondition(WinCondition):
-    # Specifically fetch only the first check of each boss, this does mean someone using !collect can cause a victory
-    # without actually completing all the bosses, but this is more stable over syncing the toon's cog suit level.
-    boss_locations = {locations.LOCATION_NAME_TO_ID.get(loc.name.value)
-            for loc in locations.BOSS_LOCATION_DEFINITIONS
-            if loc.name.value.endswith("1")}
+    boss_locations = {
+        locations.LOCATION_NAME_TO_ID.get(loc.name.value)
+        for loc in locations.BOSS_EVENT_DEFINITIONS
+    }
 
     def __init__(self, toon: DistributedToon | DistributedToonAI):
         super().__init__(toon)
@@ -91,6 +90,7 @@ class BossDefeatWinCondition(WinCondition):
 
 class GlobalTaskWinCondition(WinCondition):
     task_locations = {locations.LOCATION_NAME_TO_ID.get(loc.value) for loc in locations.ALL_TASK_LOCATIONS}
+
     def __init__(self, toon: DistributedToon | DistributedToonAI):
         super().__init__(toon)
         self.tasks_required: int = toon.slotData.get('total_tasks_required', 72)

--- a/toontown/shtiker/CheckPage.py
+++ b/toontown/shtiker/CheckPage.py
@@ -242,11 +242,13 @@ class CheckPage(ShtikerPage.ShtikerPage):
             if itemDef is None:
                 print("ALERT I DON'T KNOW WHAT %s IS -- ENRAGE AT MICA" % item_id)
                 continue
+            itemName = itemDef.name.value
+            if itemName.startswith("Defeated "):
+                continue 
             playgroundKeys = [ToontownItemName.TTC_ACCESS.value, ToontownItemName.DD_ACCESS.value,
                               ToontownItemName.DG_ACCESS.value,  ToontownItemName.MML_ACCESS.value,
                               ToontownItemName.TB_ACCESS.value,  ToontownItemName.DDL_ACCESS.value]
             button = self._makeCheckButton(model, itemDef, itemsAndCount.get(itemDef.unique_id, 0), quantity)
-            itemName = itemDef.name.value
             if itemName in playgroundKeys:
                 quantity = 2
             if "Key" in itemName or "Disguise" in itemName:
@@ -262,7 +264,6 @@ class CheckPage(ShtikerPage.ShtikerPage):
                 usefulItems.append(button[0])
             else:
                 junkItems.append(button[0])
-            # self.checkButtonsById.update({itemDef.unique_id: button})
         model.removeNode()
         del model
         self.checkButtons = keyItems + progressionItems + usefulItems + junkItems

--- a/toontown/shtiker/CheckPage.py
+++ b/toontown/shtiker/CheckPage.py
@@ -236,6 +236,7 @@ class CheckPage(ShtikerPage.ShtikerPage):
         usefulItems = []
         junkItems = []
         # Generate new buttons
+        model = loader.loadModel('phase_4/models/parties/schtickerbookHostingGUI')
         for item_id, quantity in allItems.items():
             itemDef = get_item_def_from_id(item_id)
             if itemDef is None:
@@ -244,10 +245,8 @@ class CheckPage(ShtikerPage.ShtikerPage):
             playgroundKeys = [ToontownItemName.TTC_ACCESS.value, ToontownItemName.DD_ACCESS.value,
                               ToontownItemName.DG_ACCESS.value,  ToontownItemName.MML_ACCESS.value,
                               ToontownItemName.TB_ACCESS.value,  ToontownItemName.DDL_ACCESS.value]
-
-            button = self.makeCheckButton(itemDef, itemsAndCount.get(itemDef.unique_id, 0), quantity)
+            button = self._makeCheckButton(model, itemDef, itemsAndCount.get(itemDef.unique_id, 0), quantity)
             itemName = itemDef.name.value
-            # A little hack to get around the visual funny with giving the keys on start
             if itemName in playgroundKeys:
                 quantity = 2
             if "Key" in itemName or "Disguise" in itemName:
@@ -263,14 +262,19 @@ class CheckPage(ShtikerPage.ShtikerPage):
                 usefulItems.append(button[0])
             else:
                 junkItems.append(button[0])
+            # self.checkButtonsById.update({itemDef.unique_id: button})
+        model.removeNode()
+        del model
         self.checkButtons = keyItems + progressionItems + usefulItems + junkItems
 
-    def makeCheckButton(self, itemDef, checkCount, checkMax):
+    def _makeCheckButton(self, model, itemDef, checkCount, checkMax):
+        """
+        model: loader.loadModel(loader.loadModel('phase_4/models/parties/schtickerbookHostingGUI') # avoiding loading this many times.
+        """
         checkName = itemDef.name
         command = lambda: self.setHint(checkName, itemDef, checkMax)
         checkButtonParent = DirectFrame()
         checkButtonL = DirectButton(parent=checkButtonParent, relief=None, text=checkName.value, text_pos=(0.04, 0), text_scale=0.051, text_align=TextNode.ALeft, text1_bg=self.textDownColor, text2_bg=self.textRolloverColor, text3_fg=self.textDisabledColor, textMayChange=0, command=command)
-        model = loader.loadModel('phase_4/models/parties/schtickerbookHostingGUI')
         check = model.find('**/checkmark')
         x = model.find('**/x')
         hinted = model.find('**/questionMark')
@@ -279,7 +283,6 @@ class CheckPage(ShtikerPage.ShtikerPage):
         isHinted = False
         if base.cr.archipelagoManager is not None and (localToonInformation := base.cr.archipelagoManager.getLocalInformation()) is not None:
             isHinted = any(hint.found for hint in base.localAvatar.getHintContainer().getHintsForItemAndSlot(itemDef.unique_id, localToonInformation.slotId))
-
         if checkCount >= checkMax:
             geomToUse = check
         elif isHinted:
@@ -289,8 +292,6 @@ class CheckPage(ShtikerPage.ShtikerPage):
         checkButtonR = DirectButton(parent=checkButtonParent, relief=None, image=geomToUse, image_scale=(1.25, 1.25, 1.25), pos=(0.75, 0, 0.0125), text=str(checkCount) + '/' + str(checkMax), text_scale=0.06, text_align=TextNode.ARight, text_pos=(-0.03, -0.0125), text_fg=Vec4(0, 0, 0, 0), text1_fg=Vec4(0, 0, 0, 0), text2_fg=Vec4(0, 0, 0, 1), text3_fg=Vec4(0, 0, 0, 0), command=command, text_wordwrap=13)
         # checkButtonR.bind(DirectGuiGlobals.ENTER, lambda t: self.setHint(checkName, itemDef, checkMax, hintLocations))
         # checkButtonR.bind(DirectGuiGlobals.EXIT, lambda t: self.clearHintIf(checkName))
-        model.removeNode()
-        del model
         del check
         del hinted
         del x

--- a/toontown/shtiker/LocationPage.py
+++ b/toontown/shtiker/LocationPage.py
@@ -1,4 +1,4 @@
-from collections import Counter
+import re
 from . import ShtikerPage
 from apworld.toontown import locations, options, fish, test_location, ToontownWinCondition
 from BaseClasses import MultiWorld
@@ -8,24 +8,90 @@ from panda3d.core import *
 from toontown.archipelago.definitions import util
 from ..util.ui import make_dsl_scrollable
 
+class LocationNode(DirectFrame):
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.locationNodes = []
+
+    def __createDisplay(self, text, yOffset, total) -> DirectLabel:
+        if yOffset == 25 and total > 26:
+            text=f"and {total - yOffset} more..."
+        elif yOffset > 25:
+            text=""
+        return DirectLabel(
+            parent=self, relief=None, image_scale=(1.25, 1.25, 1.25),
+            pos=(-0.36, 0, -0.06 - 0.044 * yOffset), text=text, text_scale=0.035,
+            text_align=TextNode.ALeft, text_pos=(0.03, -0.0125), text_fg=Vec4(0, 0, 0, 1),
+            text_wordwrap=24
+        )
+
+
+    def updateDisplays(self, originals: list[str]):
+
+        # Clear the old lines
+        for h in self.locationNodes:
+            h.destroy()
+        self.locationNodes.clear()
+
+        total = len(originals)
+        for index, label in enumerate(originals):
+            node = self.__createDisplay(label, index, total)
+            self.locationNodes.append(node)
+
+class LocationCategory():
+    def __init__(self, name: str, location: list[str] | str | None = None):
+        self.name = name
+        if location is None:
+            self.locations = set()
+        elif isinstance(location, str):
+            self.locations = {location}
+        else:
+            self.locations = set(location)
+
+    def add_location(self, location: str):
+        self.locations.update([location])
+
+    def get_count(self):
+        return len(self.locations)
+
+    def get_locations(self):
+        return sorted(self.locations, key=locations.LOCATION_NAME_TO_ID.get)
+    
+    def get_raw_name(self):
+        return self.name
+    
+    def get_display_name(self):
+        if self.get_count() != 1:
+            return self.name + f' ({self.get_count()}x)'
+        return self.name
+
+    def __str__(self):
+        return self.get_raw_name()
+
+
 
 class LocationPage(ShtikerPage.ShtikerPage):
 
     def __init__(self):
         ShtikerPage.ShtikerPage.__init__(self)
-        self.locationsPossible = []
+        self.locationsPossible: dict[str,LocationCategory] = {}
         self.scrollList = None
         self.textRolloverColor = Vec4(1, 1, 0, 1)
         self.textDownColor = Vec4(0.5, 0.9, 1, 1)
-        self.textDisabledColor = Vec4(0.4, 0.8, 0.4, 1)
+        self.textDisabledColor = Vec4(0.6, 0.5, 1, 1) # marks selected.
         self.locationButtons = []
+        self.LocationNode = LocationNode(self)
+        self.LocationNode.setPos(0.42, 0, 0.5)
+        self.LocationNode.hide()
+        self.selectedLocation: int | None = None
+
 
     def load(self):
         title_text_scale = 0.12
         self.title = DirectLabel(parent=self, relief=None, text=TTLocalizer.LocationPageTitle, text_scale=title_text_scale, textMayChange=0, pos=(0, 0, 0.6))
         self.gui = loader.loadModel('phase_3.5/models/gui/friendslist_gui')
         self.listXorigin = 0.02
-        self.listFrameSizeX = 0.9
+        self.listFrameSizeX = 0.86
         self.listZorigin = -0.96
         self.listFrameSizeZ = 1.04
         self.arrowButtonScale = 1.3
@@ -39,16 +105,16 @@ class LocationPage(ShtikerPage.ShtikerPage):
         ShtikerPage.ShtikerPage.enter(self)
         self.getLocations()
         self.regenerateScrollList()
+        self.LocationNode.hide()
+        self.selectedLocation = None
 
     def getLocations(self):
         # Get our checked locations
         checkedLocationIds = base.localAvatar.getCheckedLocations()
         # Get our remaining locations
-        missingLocations = []
-        # Remaining locations that should be combined
-        missingLocationsCounter = Counter()
+        missingLocations: dict[str,LocationCategory] = {}
         # Locations to force to the top of the list.
-        priorityMissingLocations = []
+        priorityMissingLocations: dict[str,LocationCategory] = {}
         # Determine forbidden location types.
         forbidden_location_types: set[locations.ToontownLocationType] = self.get_disabled_location_types()
 
@@ -65,28 +131,59 @@ class LocationPage(ShtikerPage.ShtikerPage):
 
             # Boss checks, combine the rewards into this location for the tracker.
             if location_data.type == locations.ToontownLocationType.BOSS_META:
-                priorityMissingLocations.append(location_data.name.value + f" ({base.localAvatar.slotData.get('checks_per_boss', 4)}x)")
+                obj = LocationCategory(location_data.name.value, 
+                                     [x.value for x in locations.REGION_TO_BOSS_LOCATIONS.get(location_data.region)])
+                priorityMissingLocations.update({location_data.name.value:obj})
                 continue
             # Locations that are identical with only a number appended.
             if location_data.type in locations.TREASURE_LOCATION_TYPES + locations.TASK_LOCATION_TYPES:
-                without_number = location_data.name.value.rsplit(" ", 1)[0]
-                missingLocationsCounter.update([without_number])
-                continue
-            #Other locations to combine.
-            # if location_data.region == locations.ToontownRegionName.GALLERY:
-            #     missingLocationsCounter.update(['Cog ' + location_data.type.name.replace('_', ' ').title()])
-            #     continue
-            if location_data.region == locations.ToontownRegionName.FISHING:
-                missingLocationsCounter.update([location_data.type.name.title()])
-                continue
-            if location_data.type == locations.ToontownLocationType.PET_SHOP:
-                missingLocationsCounter.update([location_data.region.name + " Pet Shop"])
-                continue
-            missingLocations.append(location_data.name.value)
-        
-        countedMissingLocations = [location +f" ({count}x)" for location, count in missingLocationsCounter.items()]
+                name = location_data.name.value.rsplit(" ", 1)[0]
+                obj = missingLocations.get(name, LocationCategory(name))
+                obj.add_location(location_data.name.value)
 
-        self.locationsPossible =  priorityMissingLocations + countedMissingLocations + missingLocations
+            elif location_data.region == locations.ToontownRegionName.GALLERY:
+                name = location_data.name.value.split('(')[0].rstrip()
+                obj = missingLocations.get(name, LocationCategory(name))
+                obj.add_location(location_data.name.value)
+
+            elif location_data.region in [locations.ToontownRegionName.FISHING]:
+                name = location_data.type.name.title()
+                obj = missingLocations.get(name, LocationCategory(name))
+                obj.add_location(location_data.name.value)
+
+            elif location_data.type == locations.ToontownLocationType.PET_SHOP:
+                name=location_data.region.name + " Pet Shop"
+                obj = missingLocations.get(name, LocationCategory(name))
+                obj.add_location(location_data.name.value)
+
+            elif location_data.type == locations.ToontownLocationType.GAG_TRAINING:
+                name = location_data.rules[0].name
+                name = re.sub(r'(?<=\B)([A-Z])', r' \1', name).rsplit(" ", 1)[0] + " Training"
+                obj = missingLocations.get(name, LocationCategory(name))
+                obj.add_location(location_data.name.value)
+
+            elif location_data.type == locations.ToontownLocationType.FACILITIES:
+                name = location_data.rules[0].name
+                name = re.sub(r'(?<=\B)([A-Z])', r' \1', name).rsplit(" ", 1)[0]
+                obj = missingLocations.get(name, LocationCategory(name))
+                obj.add_location(location_data.name.value)
+
+            elif location_data.type == locations.ToontownLocationType.BUILDINGS:
+                name = "Building Clear"
+                obj = missingLocations.get(name, LocationCategory(name))
+                obj.add_location(location_data.name.value)
+
+            elif location_data.type in [locations.ToontownLocationType.RACING, locations.ToontownLocationType.GOLF]:
+                name = location_data.type.name.title()
+                obj = missingLocations.get(name, LocationCategory(name))
+                obj.add_location(location_data.name.value)
+
+            else:
+                name = location_data.name.value
+                obj = LocationCategory(name, name)
+            missingLocations.update({name:obj})
+
+        self.locationsPossible = {**priorityMissingLocations, **missingLocations}
 
     def get_disabled_location_types(self) -> set[locations.ToontownLocationType]:
         """
@@ -134,9 +231,6 @@ class LocationPage(ShtikerPage.ShtikerPage):
 
         return forbidden_location_types
 
-    def exit(self):
-        super().exit()
-
     def regenerateScrollList(self):
         selectedIndex = 0
         if self.scrollList:
@@ -167,7 +261,7 @@ class LocationPage(ShtikerPage.ShtikerPage):
             self.listXorigin + self.listFrameSizeX,
             self.listZorigin,
             self.listZorigin + self.listFrameSizeZ), itemFrame_frameColor=(0.85, 0.95, 1, 1),
-            itemFrame_borderWidth=(0.01, 0.01), numItemsVisible=15, forceHeight=0.065, items=self.locationButtons
+            itemFrame_borderWidth=(0.01, 0.01), numItemsVisible=15, forceHeight=0.065, items=self.locationButtons #Frames
         )
         make_dsl_scrollable(self.scrollList)
         self.scrollList.scrollTo(selectedIndex)
@@ -178,15 +272,25 @@ class LocationPage(ShtikerPage.ShtikerPage):
         for button in self.locationButtons:
             button.detachNode()
             del button
+        self.selectedLocation = False
         self.locationButtons = []
 
         # Generate new buttons
-        for location in self.locationsPossible:
-            button = self.makeLocationButton(location)
-            self.locationButtons.append(button[0])
+        for index, location in enumerate(self.locationsPossible.values()):
+            button = self.makeLocationButton(index, location)
+            self.locationButtons.append(button)
 
-    def makeLocationButton(self, location):
-        locationName = location
-        locationButtonParent = DirectFrame()
-        locationButton = DirectButton(parent=locationButtonParent, relief=None, text=locationName, text_pos=(0.04, 0), text_scale=0.051, text_align=TextNode.ALeft, text1_bg=self.textDownColor, text2_bg=self.textRolloverColor, text3_fg=self.textDisabledColor, textMayChange=0)
-        return (locationButtonParent, locationButton)
+
+    def makeLocationButton(self, index: int, location: LocationCategory):
+        locationName = location.get_display_name()
+        command = lambda: self.setLocations(index, location)
+        locationButton = DirectButton(relief=None, text=locationName, text_pos=(0.04, 0), text_scale=0.051, text_align=TextNode.ALeft, text1_bg=self.textDownColor, text2_bg=self.textRolloverColor, text3_bg=self.textDisabledColor, textMayChange=0, command=command)
+        return locationButton
+
+    def setLocations(self, index, location: LocationCategory):
+        self.LocationNode.show()
+        self.LocationNode.updateDisplays(location.get_locations())
+        self.locationButtons[index]['state'] = DGG.DISABLED
+        if not self.selectedLocation is None:
+            self.locationButtons[self.selectedLocation]['state'] = DGG.NORMAL
+        self.selectedLocation = index

--- a/toontown/shtiker/LocationPage.py
+++ b/toontown/shtiker/LocationPage.py
@@ -73,9 +73,9 @@ class LocationPage(ShtikerPage.ShtikerPage):
                 missingLocationsCounter.update([without_number])
                 continue
             #Other locations to combine.
-            if location_data.region == locations.ToontownRegionName.GALLERY:
-                missingLocationsCounter.update(['Cog ' + location_data.type.name.replace('_', ' ').title()])
-                continue
+            # if location_data.region == locations.ToontownRegionName.GALLERY:
+            #     missingLocationsCounter.update(['Cog ' + location_data.type.name.replace('_', ' ').title()])
+            #     continue
             if location_data.region == locations.ToontownRegionName.FISHING:
                 missingLocationsCounter.update([location_data.type.name.title()])
                 continue

--- a/toontown/suit/DistributedBossbotBossAI.py
+++ b/toontown/suit/DistributedBossbotBossAI.py
@@ -643,15 +643,14 @@ class DistributedBossbotBossAI(DistributedBossCogAI.DistributedBossCogAI, FSM.FS
         for toonId in self.involvedToons:
             toon = self.air.doId2do.get(toonId)
             if toon:
-                bundleCount = toon.slotData.get('checks_per_boss', 4)
-                bundle = [locations.ToontownLocationName.BOSSBOT_PROOF_1.value,
-                          locations.ToontownLocationName.BOSSBOT_PROOF_2.value,
-                          locations.ToontownLocationName.BOSSBOT_PROOF_3.value,
-                          locations.ToontownLocationName.BOSSBOT_PROOF_4.value,
-                          locations.ToontownLocationName.BOSSBOT_PROOF_5.value]
-                if bundleCount:
-                    for checkNum in range(bundleCount):
-                        toon.addCheckedLocation(ap_location_name_to_id(bundle[checkNum]))
+                toon.addCheckedLocations([ap_location_name_to_id(location) for location in [
+                    locations.ToontownLocationName.BOSSBOT_PROOF_1.value,
+                    locations.ToontownLocationName.BOSSBOT_PROOF_2.value,
+                    locations.ToontownLocationName.BOSSBOT_PROOF_3.value,
+                    locations.ToontownLocationName.BOSSBOT_PROOF_4.value,
+                    locations.ToontownLocationName.BOSSBOT_PROOF_5.value,
+                    locations.ToontownLocationName.FIGHT_CEO.value
+                ]])
                 self.givePinkSlipReward(toon)
                 toon.b_promote(self.deptIndex)
 

--- a/toontown/suit/DistributedCashbotBossAI.py
+++ b/toontown/suit/DistributedCashbotBossAI.py
@@ -1125,15 +1125,14 @@ class DistributedCashbotBossAI(DistributedBossCogAI.DistributedBossCogAI, FSM.FS
         for toonId in self.involvedToons:
             toon = self.air.doId2do.get(toonId)
             if toon:
-                bundleCount = toon.slotData.get('checks_per_boss', 4)
-                bundle = [locations.ToontownLocationName.CASHBOT_PROOF_1.value,
-                          locations.ToontownLocationName.CASHBOT_PROOF_2.value,
-                          locations.ToontownLocationName.CASHBOT_PROOF_3.value,
-                          locations.ToontownLocationName.CASHBOT_PROOF_4.value,
-                          locations.ToontownLocationName.CASHBOT_PROOF_5.value]
-                if bundleCount:
-                    for checkNum in range(bundleCount):
-                        toon.addCheckedLocation(ap_location_name_to_id(bundle[checkNum]))
+                toon.addCheckedLocations([ap_location_name_to_id(location) for location in [
+                    locations.ToontownLocationName.CASHBOT_PROOF_1.value,
+                    locations.ToontownLocationName.CASHBOT_PROOF_2.value,
+                    locations.ToontownLocationName.CASHBOT_PROOF_3.value,
+                    locations.ToontownLocationName.CASHBOT_PROOF_4.value,
+                    locations.ToontownLocationName.CASHBOT_PROOF_5.value,
+                    locations.ToontownLocationName.FIGHT_CFO.value
+                ]])
                 toon.b_promote(self.deptIndex)
 
                 for rewardId in rewards:

--- a/toontown/suit/DistributedLawbotBossAI.py
+++ b/toontown/suit/DistributedLawbotBossAI.py
@@ -705,15 +705,14 @@ class DistributedLawbotBossAI(DistributedBossCogAI.DistributedBossCogAI, FSM.FSM
         for toonId in self.involvedToons:
             toon = self.air.doId2do.get(toonId)
             if toon:
-                bundleCount = toon.slotData.get('checks_per_boss', 4)
-                bundle = [locations.ToontownLocationName.LAWBOT_PROOF_1.value,
-                          locations.ToontownLocationName.LAWBOT_PROOF_2.value,
-                          locations.ToontownLocationName.LAWBOT_PROOF_3.value,
-                          locations.ToontownLocationName.LAWBOT_PROOF_4.value,
-                          locations.ToontownLocationName.LAWBOT_PROOF_5.value]
-                if bundleCount:
-                    for checkNum in range(bundleCount):
-                        toon.addCheckedLocation(ap_location_name_to_id(bundle[checkNum]))
+                toon.addCheckedLocations([ap_location_name_to_id(location) for location in [
+                    locations.ToontownLocationName.LAWBOT_PROOF_1.value,
+                    locations.ToontownLocationName.LAWBOT_PROOF_2.value,
+                    locations.ToontownLocationName.LAWBOT_PROOF_3.value,
+                    locations.ToontownLocationName.LAWBOT_PROOF_4.value,
+                    locations.ToontownLocationName.LAWBOT_PROOF_5.value,
+                    locations.ToontownLocationName.FIGHT_CJ.value
+                ]])
                 for reward in range(numRewards):
                     preferredDept = random.randrange(len(SuitDNA.suitDepts))
                     typeWeights = ['single'] * 70 + ['building'] * 27 + ['invasion'] * 3

--- a/toontown/suit/DistributedSellbotBossAI.py
+++ b/toontown/suit/DistributedSellbotBossAI.py
@@ -432,15 +432,14 @@ class DistributedSellbotBossAI(DistributedBossCogAI.DistributedBossCogAI, FSM.FS
         for toonId in self.involvedToons:
             toon = self.air.doId2do.get(toonId)
             if toon:
-                bundleCount = toon.slotData.get('checks_per_boss', 4)
-                bundle = [locations.ToontownLocationName.SELLBOT_PROOF_1.value,
-                          locations.ToontownLocationName.SELLBOT_PROOF_2.value,
-                          locations.ToontownLocationName.SELLBOT_PROOF_3.value,
-                          locations.ToontownLocationName.SELLBOT_PROOF_4.value,
-                          locations.ToontownLocationName.SELLBOT_PROOF_5.value]
-                if bundleCount:
-                    for checkNum in range(bundleCount):
-                        toon.addCheckedLocation(ap_location_name_to_id(bundle[checkNum]))
+                toon.addCheckedLocations([ap_location_name_to_id(location) for location in [
+                    locations.ToontownLocationName.SELLBOT_PROOF_1.value,
+                    locations.ToontownLocationName.SELLBOT_PROOF_2.value,
+                    locations.ToontownLocationName.SELLBOT_PROOF_3.value,
+                    locations.ToontownLocationName.SELLBOT_PROOF_4.value,
+                    locations.ToontownLocationName.SELLBOT_PROOF_5.value,
+                    locations.ToontownLocationName.FIGHT_VP.value
+                ]])
 
                 configMax = simbase.config.GetInt('max-sos-cards', 16)
                 if configMax == 8:

--- a/toontown/toon/DistributedToon.py
+++ b/toontown/toon/DistributedToon.py
@@ -2853,9 +2853,6 @@ class DistributedToon(DistributedPlayer.DistributedPlayer, Toon.Toon, Distribute
     def setReceivedItems(self, receivedItems: List[Tuple[int, int]]):
         self.receivedItems = receivedItems
         self.receivedItemIDs = set(x[1] for x in receivedItems)
-        if self.isLocal():
-            if hasattr(base.localAvatar, 'checkPage'):
-                base.localAvatar.checkPage.regenerateScrollList()
 
     # Get a list of item IDs this toon has received via AP
     def getReceivedItems(self) -> List[Tuple[int, int]]:

--- a/toontown/toon/DistributedToonAI.py
+++ b/toontown/toon/DistributedToonAI.py
@@ -4454,7 +4454,6 @@ class DistributedToonAI(DistributedPlayerAI.DistributedPlayerAI, DistributedSmoo
         return location in self.checkedLocations
 
     def addCheckedLocation(self, location: int):
-
         if self.hasCheckedLocation(location):
             return
 
@@ -4465,7 +4464,6 @@ class DistributedToonAI(DistributedPlayerAI.DistributedPlayerAI, DistributedSmoo
             self.archipelago_session.complete_check(location)
 
     def addCheckedLocations(self, locations: List[int]):
-
         self.checkedLocations.extend(locations)
         unique = set(self.checkedLocations)
         self.checkedLocations = list(unique)
@@ -4473,11 +4471,15 @@ class DistributedToonAI(DistributedPlayerAI.DistributedPlayerAI, DistributedSmoo
         self.b_setCheckedLocations(self.checkedLocations)
 
         if self.archipelago_session:
-            self.archipelago_session.complete_checks(self.checkedLocations)
+            self.archipelago_session.complete_checks(list(locations))
 
     # Called when recieving locations from Archipelago.
     def receiveCheckedLocations(self, locations: List[int]):
-        self.addCheckedLocations(locations)
+        self.checkedLocations.extend(locations)
+        unique = set(self.checkedLocations)
+        self.checkedLocations = list(unique)
+
+        self.b_setCheckedLocations(self.checkedLocations)
 
 
 


### PR DESCRIPTION
Fixes a few issues with win conditions in the current release:
* Hood tasks currently let you goal with just completing one playground.
* Cog Bosses don't sync like every other win condition does (now checks if AP locations have been checked)
* ~~Ensures a single boss reward exists if the win condition has bosses as a requirement, and excludes it from logic if it needs to add one for this.~~
* redoes the logic in task goals to avoid converting the toon's full checked locations list into a set every time the win condition is checked, instead creating a class variable containing the goal's locations and using that to compare.

All of them aren't tested all the way to being able to goal, Hood Tasks saw tasks being completed at any rate, it correctly skips ttc when listing tasks left on a toon that had TTC fully cleared of tasks.

edit: 2024-11-19
changes how one of those issues were fixed above, and some performance and transfer improvements.
* Adds a dummy item and location for Cog Bosses, to be used by flippy to check if the toon has defeated enough bosses, and to later combine the bundles in the tracker into.
* Doesn't call ChecksPage.regenerateScrollList() every time you get an item, just when you open the page now. (this could become outdated if you keep the page open, but you'd have to be present doing that, since going afk still closes the book.)
* reduces the impact of regenerateScrollList - moving the asset loading outside the loop, so it doesn't get loaded and unloaded once for every single item.
* stops sending every single location to AP when adding multiple locations at once (it gets fully synced on connect already), and also replying with all our locations when archipelago tells us we checked a location we didn't have before. (packet size reduction from ~200b-2kb increasing the more items you have -> a static ~~100b, depending on how many checks are being sent at once)