### PR TITLE
DiscordRPC: Fix bug where discord would crash the game if you close it

### DIFF
--- a/toontown/discord/DiscordRPC.py
+++ b/toontown/discord/DiscordRPC.py
@@ -135,8 +135,8 @@ class DiscordRPC(object):
             except (PipeClosed, BrokenPipeError) :
                 # schedule a task to try to reconnect to the discord
                 self.discordRPC = None
-                self.notify.warning('Discord RPC connection lost, trying to reconnect in 5 seconds.')
-                taskMgr.doMethodLater(5, self.reconnectDiscord, 'DiscordTask')
+                self.notify.warning('Discord RPC connection lost, trying to reconnect in 30 seconds.')
+                taskMgr.doMethodLater(30, self.reconnectDiscord, 'DiscordTask')
             
     def reconnectDiscord(self, task):
         self.enable()
@@ -229,10 +229,10 @@ class DiscordRPC(object):
                     self.notify.warning(f"Failed to connect to Discord RPC: {e}")
                     self.discordRPC = None
                 except ConnectionError:
-                    self.notify.warning("Failed to connect to Discord RPC: Connection Error, trying to reconnect in 5 seconds.")
+                    self.notify.debug("Failed to connect to Discord RPC: Connection Error, trying to reconnect in 30 seconds.")
                     self.discordRPC = None
                     # schedule a task to try again later
-                    taskMgr.doMethodLater(5, self.reconnectDiscord, 'DiscordTask')
+                    taskMgr.doMethodLater(30, self.reconnectDiscord, 'DiscordTask')
                     
         except PyPresenceException:
             self.notify.warning("Discord not found for this client.")


### PR DESCRIPTION
Fixes issue #174

This pull request includes several changes to improve the Discord Rich Presence functionality in the `toontown/discord/DiscordRPC.py` file. The changes primarily focus on handling connection issues more gracefully and ensuring the application can attempt to reconnect if the connection to Discord is lost.

### Improvements to connection handling:

* Added import for `PipeClosed` exception from `pypresence.exceptions` to handle specific pipe closure errors.

* In the `setData` method, added a try-except block to catch `PipeClosed` and `BrokenPipeError` exceptions. If an exception is caught, the method schedules a task to attempt reconnection to Discord after 30 seconds.

* Added a new method `reconnectDiscord` to handle the reconnection logic. This method is called by the scheduled task when a connection error occurs.

* In the `enable` method, added handling for `ConnectionError` exceptions. If a connection error occurs, the method schedules a task to attempt reconnection to Discord after 30 seconds.