### PR TITLE
Setting: New setting to toggle laff overhead display

### DIFF
--- a/toontown/settings/Settings.py
+++ b/toontown/settings/Settings.py
@@ -66,6 +66,7 @@ class Settings:
         'discord-rich-presence': False,
         "archipelago-textsize": 0.5,
         "color-blind-mode": False,
+        'laff-display': True,
     }
     settingsFile = Path.home() / "Documents" / "Toontown Archipelago" / "settings.json"
 

--- a/toontown/shtiker/OptionsPage.py
+++ b/toontown/shtiker/OptionsPage.py
@@ -41,6 +41,7 @@ OptionToType = {
     'archipelago-textsize': OptionTypes.SLIDER,
     'color-blind-mode': OptionTypes.BUTTON,
     'want-legacy-models': OptionTypes.BUTTON,
+    'laff-display': OptionTypes.BUTTON,
 
     # Privacy
     "competitive-boss-scoring": OptionTypes.BUTTON,
@@ -144,6 +145,7 @@ class OptionsTabPage(DirectFrame, FSM):
             'archipelago-textsize',
             'color-blind-mode',
             'want-legacy-models',
+            'laff-display'
 
         ],
         "Privacy": [
@@ -764,6 +766,8 @@ class OptionElement(DirectFrame):
             base.colorBlindMode = newSetting
         elif self.optionName == "want-legacy-models":
             base.WANT_LEGACY_MODELS = newSetting
+        elif self.optionName == "laff-display":
+            base.laffMeterDisplay = newSetting
 
         # Update the button text with the new setting.
         self.optionModifier["text"] = self.formatSetting(newSetting)

--- a/toontown/toon/DistributedToon.py
+++ b/toontown/toon/DistributedToon.py
@@ -305,20 +305,26 @@ class DistributedToon(DistributedPlayer.DistributedPlayer, Toon.Toon, Distribute
             self.setColorProfile(colorProfile)
 
     def setHp(self, hitPoints):
-        if not self.overheadLaffMeter:
+        if not self.overheadLaffMeter and base.laffMeterDisplay:
             self.makeOverheadLaffMeter()
+        # we do have one but we don't have the display enabled, destroy it.
+        elif self.overheadLaffMeter and not base.laffMeterDisplay:
+            self.destroyOverheadLaffMeter()
         super().setHp(hitPoints)
 
     def setMaxHp(self, hitPoints):
-        if not self.overheadLaffMeter:
+        if not self.overheadLaffMeter and base.laffMeterDisplay:
             self.makeOverheadLaffMeter()
+        # we do have one but we don't have the display enabled, destroy it.
+        elif self.overheadLaffMeter and not base.laffMeterDisplay:
+            self.destroyOverheadLaffMeter()
         super().setMaxHp(hitPoints)
 
     def makeOverheadLaffMeter(self):
 
         self.destroyOverheadLaffMeter()
 
-        if self.maxHp and self.hp:
+        if self.maxHp and self.hp and base.laffMeterDisplay:
             self.overheadLaffMeter = LaffMeter(self.style, self.hp, self.maxHp)
             self.overheadLaffMeter.setAvatar(self)
             self.overheadLaffMeter.reparentTo(self.nametag.getNameIcon())

--- a/toontown/toonbase/TTLocalizerEnglish.py
+++ b/toontown/toonbase/TTLocalizerEnglish.py
@@ -9959,6 +9959,7 @@ OptionNames = {
     "archipelago-textsize": "Archipelago Log Text Size",
     "color-blind-mode": "Colorblind Mode",
     "want-legacy-models": "Toggle TTO Species Models*",
+    'laff-display': "Toggle Laff Meter Overhead Display",
 
     # Privacy
     "competitive-boss-scoring": "Want Competitive Boss Scoring",

--- a/toontown/toonbase/ToonBase.py
+++ b/toontown/toonbase/ToonBase.py
@@ -197,6 +197,8 @@ class ToonBase(OTPBase.OTPBase):
         self.WANT_LEGACY_MODELS = self.settings.get('want-legacy-models')
         self.wantRichPresence = self.settings.get('discord-rich-presence')
         self.colorBlindMode = self.settings.get('color-blind-mode')
+        # do they want laff meter on or off?
+        self.laffMeterDisplay = self.settings.get('laff-meter-display')
         self.discord = DiscordRPC()
         self.discord.launching()
         self.ap_version_text = OnscreenText(text=f"Toontown: Archipelago {version}", parent=self.a2dBottomLeft, pos=(.3, .05), mayChange=False, sort=-100, scale=.04, fg=(1, 1, 1, .3), shadow=(0, 0, 0, .3), align=TextNode.ALeft)


### PR DESCRIPTION
This pull request introduces a new feature to toggle the overhead Laff Meter display in Toontown. The changes span multiple files to implement this feature, including adding a new setting and updating the relevant UI and behavior.

Key changes include:

### Settings and Configuration

* Added a new setting `'laff-display'` to the `Settings` class, defaulting to `True`. (`toontown/settings/Settings.py`)
* Initialized the `laffMeterDisplay` attribute in the `ToonBase` class based on the new setting. (`toontown/toonbase/ToonBase.py`)

### User Interface

* Added `'laff-display'` to the `OptionTypes` and `OptionsTabPage` classes, allowing it to be toggled via a button in the options menu. (`toontown/shtiker/OptionsPage.py`) [[1]](diffhunk://#diff-a56ace02b252e33b0b7e8dbf64f441ee8f6178cb69348f6700122ce71296afedR44) [[2]](diffhunk://#diff-a56ace02b252e33b0b7e8dbf64f441ee8f6178cb69348f6700122ce71296afedR148)
* Updated the `_updateButtonOption` method to handle changes to the `laff-display` setting. (`toontown/shtiker/OptionsPage.py`)

### Behavior

* Modified the `setHp` and `setMaxHp` methods in the `DistributedToon` class to create or destroy the overhead Laff Meter based on the `laffMeterDisplay` setting. (`toontown/toon/DistributedToon.py`)

### Localization

* Added a localization string for the new `'laff-display'` option. (`toontown/toonbase/TTLocalizerEnglish.py`)