### PR TITLE
OrbitalCamera: Fix issue where "the orbital camera will get stuck abo…

### DIFF
--- a/toontown/toon/OrbitalCamera.py
+++ b/toontown/toon/OrbitalCamera.py
@@ -429,7 +429,6 @@ class OrbitalCamera(FSM, NodePath, ParamObj):
     def _startMouseControlTasks(self):
         if self.mouseControl:
             properties = WindowProperties()
-            properties.setMouseMode(properties.MRelative)
             base.win.requestProperties(properties)
             self._startMouseReadTask()
             self._startMouseUpdateTask()


### PR DESCRIPTION
…ut 20 degrees from center and not move." Only on mac

This was due to a mouse mode only for unix lol.
fixes #84

Now unix will act like windows