### PR TITLE
apworld: change functionality of 'randomized' in gags and win conditions

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -39,6 +39,8 @@ class Toggle(Option):
 
 class OptionSet(Option):
     pass
+class OptionList(Option):
+    pass
 
 #Used by the APWorld for supporting OptionGroups for display on the website. 
 class OptionGroup():

--- a/apworld/EXAMPLE_TOONTOWN.yaml
+++ b/apworld/EXAMPLE_TOONTOWN.yaml
@@ -74,65 +74,41 @@ Toontown:
 
   ### Completion Settings ###
 
-  win_condition:
   # Determines the condition required before being able to talk to Flippy to complete the game.
-  # at least one of these should be enabled (remove the # before the option to enable them)
-
-  # - (Default) Player must defeat a number of cog bosses to complete the game (determined by cog_bosses_required).
-  - cog-bosses
-
-  # - Player must reach a certain number of bounty checks to complete the game (determined by bounties_required, total_bounties)
-  # - Bounties can be on late/challenging checks such as max fishing, each cog boss, maxing gags, etc.
-  #- bounties
-  
-  # - Player must complete a total number of tasks to complete the game (determined by total_tasks_required).
-  #- total-tasks
-  
-  # - Player must complete a number of tasks from each neighborhood to complete the game (determined by hood_tasks_required).
-  #- hood-tasks
-  
-  # - Player must max a certain amount of gag tracks to complete the game (determined by gag_tracks_required).
-  #- gag-tracks
-  
-  # - Player must catch a certain amount of fish species to complete the game (determined by fish_species_required).
-  #- fish-species
-  
-  # - Player must reach a certain amount of laff to complete the game (determined by laff_points_required).
-  # - - NOTE: laff_o_lympics replaces ALL laff boost items with only +1 Laff Boosts
-  #- laff-o-lympics
-  
-  # - A randomly selected of the above options will be added to the required conditions.
-  # - - This can be added multiple times.
-  #- randomized
-  #- randomized
-  #- randomized
+  # at least one of these should be enabled.
+  # valid keys: ["cog-bosses", "bounties", "total-tasks", "hood-tasks", "gag-tracks",
+  # "fish-species", "laff_o_lympics", "randomized"]
+  # "randomized" will be replaced with one of the other options, if possible, and is valid multiple times.
+  # for a description for the other options, see all the options below ending in '_required'.
+  win_condition: [ "cog-bosses" ]
 
   # How many cog bosses must be defeated before being able to talk to Flippy to complete the game
+  # Unused if win_condition is not cog-bosses
   # Range: 0 to 4
   cog_bosses_required: 4
   
   # How many total tasks must be finished before being able to talk to Flippy to complete the game.
-  # Unused if win_condition is not total_tasks.
+  # Unused if win_condition is not total-tasks.
   # Range: 0 to 72
   total_tasks_required: 48
   
   # How many tasks must be finished in each neighborhood before being able to talk to Flippy to complete the game.
-  # Unused if win_condition is not hood_tasks.
+  # Unused if win_condition is not hood-tasks.
   # Range: 0 to 12
   hood_tasks_required: 8
   
   # How many gag tracks must be maxxed before being able to talk to Flippy to complete the game
-  # Unused if win_condition is not total_gag_tracks
+  # Unused if win_condition is not gag-tracks
   # Range 0 to 7
   gag_tracks_required: 5
 
   # How many fish species must be caught before being able to talk to Flippy to complete the game
-  # Unused if win_condition is not total_fish_species
+  # Unused if win_condition is not fish-species
   # Range 0 to 70
   fish_species_required: 70
 
   # How many laff points we must have before being able to talk to Flippy to complete the game
-  # Unused if win_condition is not laff_o_lympics
+  # Unused if win_condition is not laff-o-lympics
   # Setting must be below or equal to max_laff setting
   # Range 0 to 150
   laff_points_required: 120
@@ -140,12 +116,12 @@ Toontown:
   # BOUNTY SETTINGS #
 
   # How many bounties we must have before being able to talk to Flippy to complete the game
-  # Unused if win_condition is not bounty
+  # Unused if win_condition is not bounties
   # Range 0 to 32
   bounties_required: 10
 
   # How many bounties are in the pool.
-  # Unused if win_condition is not bounty
+  # Unused if win_condition is not bounties
   # Must be equal to or above bounties_required
   # Range 1 to 32
   total_bounties: 20

--- a/apworld/EXAMPLE_TOONTOWN.yaml
+++ b/apworld/EXAMPLE_TOONTOWN.yaml
@@ -35,16 +35,15 @@ Toontown:
   max_global_gag_xp: 30
 
   starting_gags:
-    # The gags to have when starting a new game.
-    # ["randomized"] will ensure you have 2 tracks, at least one being a usable offensive track.
-    # If you select two other tracks here, "randomized" will do nothing.
+    # The gags to have when starting a new game. using "randomized" instead of a gag will replace with a random extra gag.
+    # you cannot start with gags above level 1, duplicate values other than "randomized" will be ignored.
     # 
     # valid keys: {"randomized", "toonup", "trap", "lure", "sound", "throw", "squirt", "drop"}
     # ex. ["toonup, "sound"] will start you with toonup and sound as starting tracks
     # ex. ["sound"] will start you with only sound as a starting track
     # An empty list will start you with no gag tracks
-    ['randomized']
-  
+    ['randomized', 'randomized']
+
   # The percentage of damage that will be done when battling Cogs.
   # 50 -> 50%/Half damage, 200 -> 200%/2x damage, etc.
   # Range: 25 to 500
@@ -75,26 +74,40 @@ Toontown:
 
   ### Completion Settings ###
 
-  # The Following Settings determines the conditions required before being able to talk to Flippy to complete the game.
-  # At least one of these should be enabled, otherwise the game will immediately complete.
+  win_condition:
+  # Determines the condition required before being able to talk to Flippy to complete the game.
+  # at least one of these should be enabled (remove the # before the option to enable them)
+
   # - (Default) Player must defeat a number of cog bosses to complete the game (determined by cog_bosses_required).
-  win_condition_cog_bosses: "true"
+  - cog-bosses
+
   # - Player must reach a certain number of bounty checks to complete the game (determined by bounties_required, total_bounties)
   # - Bounties can be on late/challenging checks such as max fishing, each cog boss, maxing gags, etc.
-  win_condition_bounty: 'false'
+  #- bounties
+  
   # - Player must complete a total number of tasks to complete the game (determined by total_tasks_required).
-  win_condition_total_tasks: "false"
+  #- total-tasks
+  
   # - Player must complete a number of tasks from each neighborhood to complete the game (determined by hood_tasks_required).
-  win_condition_hood_tasks: "false"
+  #- hood-tasks
+  
   # - Player must max a certain amount of gag tracks to complete the game (determined by gag_tracks_required).
-  win_condition_gag_tracks: "false"
+  #- gag-tracks
+  
   # - Player must catch a certain amount of fish species to complete the game (determined by fish_species_required).
-  win_condition_fish_species: "false"
+  #- fish-species
+  
   # - Player must reach a certain amount of laff to complete the game (determined by laff_points_required).
   # - - NOTE: laff_o_lympics replaces ALL laff boost items with only +1 Laff Boosts
-  win_condition_laff_o_lympics: "false"
+  #- laff-o-lympics
+  
+  # - A randomly selected of the above options will be added to the required conditions.
+  # - - This can be added multiple times.
+  #- randomized
+  #- randomized
+  #- randomized
 
-  # How many cog bosses must be defeated before being able to talk to Flippy to complete the game.
+  # How many cog bosses must be defeated before being able to talk to Flippy to complete the game
   # Range: 0 to 4
   cog_bosses_required: 4
   

--- a/apworld/EXAMPLE_TOONTOWN.yaml
+++ b/apworld/EXAMPLE_TOONTOWN.yaml
@@ -34,15 +34,14 @@ Toontown:
   # Range: 0 to 30
   max_global_gag_xp: 30
 
-  starting_gags:
-    # The gags to have when starting a new game. using "randomized" instead of a gag will replace with a random extra gag.
-    # you cannot start with gags above level 1, duplicate values other than "randomized" will be ignored.
-    # 
-    # valid keys: {"randomized", "toonup", "trap", "lure", "sound", "throw", "squirt", "drop"}
-    # ex. ["toonup, "sound"] will start you with toonup and sound as starting tracks
-    # ex. ["sound"] will start you with only sound as a starting track
-    # An empty list will start you with no gag tracks
-    ['randomized', 'randomized']
+  # The gags to have when starting a new game. using "randomized" instead of a gag will replace with a random extra gag.
+  # you cannot start with gags above level 1, duplicate values other than "randomized" will be ignored.
+  # 
+  # valid keys: ["randomized", "toonup", "trap", "lure", "sound", "throw", "squirt", "drop"]
+  # ex. ["toonup, "sound"] will start you with toonup and sound as starting tracks
+  # ex. ["sound"] will start you with only sound as a starting track
+  # An empty list will start you with no gag tracks
+  starting_gags: ['randomized', 'randomized']
 
   # The percentage of damage that will be done when battling Cogs.
   # 50 -> 50%/Half damage, 200 -> 200%/2x damage, etc.
@@ -75,12 +74,23 @@ Toontown:
   ### Completion Settings ###
 
   # Determines the condition required before being able to talk to Flippy to complete the game.
-  # at least one of these should be enabled.
+  # At least one of these should be enabled.
+
   # valid keys: ["cog-bosses", "bounties", "total-tasks", "hood-tasks", "gag-tracks",
-  # "fish-species", "laff_o_lympics", "randomized"]
-  # "randomized" will be replaced with one of the other options, if possible, and is valid multiple times.
-  # for a description for the other options, see all the options below ending in '_required'.
-  win_condition: [ "cog-bosses" ]
+  #              "fish-species", "laff-o-lympics", "randomized"]
+
+  # "cog-bosses" - Player must defeat enough bosses (determined by cog_bosses_required)
+  # "bounties" - Player must collect enough bounties in their own world (determined by bounties_required, total_bounties)
+  # "total-tasks" - Player must complete enough ToonTasks (determined by total_tasks_required)
+  # "hood-tasks" - Player must complete enough ToonTasks in each Playground (determined by hood_tasks_required)
+  # "gag-tracks" - Player must max enough Gag Tracks (determined by gag_tracks_required)
+  # "fish-species" - Player must catch enough fish species (determined by fish_species_required)
+  # "laff-o-lympics" - Player must reach a certain amount of laff (determined by laff_points_required)
+  #                    NOTE: Replaces ALL Laff Boosts with +1 Laff Boosts
+  # "randomized" - Will choose a random not-yet chosen goal as one of your goals.
+  #                NOTE: Can be input into the below list multiple times for multiple random goals
+  # Examples: ["cog-bosses", "hood-tasks"] | ["randomized", "randomized", "gag-tracks"]
+  win_condition: ["cog-bosses"]
 
   # How many cog bosses must be defeated before being able to talk to Flippy to complete the game
   # Unused if win_condition is not cog-bosses

--- a/apworld/toontown/__init__.py
+++ b/apworld/toontown/__init__.py
@@ -3,9 +3,7 @@ from typing import Dict, Any, List
 from BaseClasses import Tutorial, Region, ItemClassification, CollectionState, Location, LocationProgressType
 from worlds.AutoWorld import World, WebWorld
 import random
-from worlds.generic.Rules import set_rule
 import logging
-
 from . import regions, consts
 from .consts import ToontownItem, ToontownLocation, ToontownWinCondition
 from .items import ITEM_DESCRIPTIONS, ITEM_DEFINITIONS, ToontownItemDefinition, get_item_def_from_id, ToontownItemName, \
@@ -90,11 +88,24 @@ class ToontownWorld(World):
         return ToontownItem(event, ItemClassification.progression_skip_balancing, None, self.player)
 
     def generate_early(self) -> None:
+        # Convert web options to standard options, if the relevant standard option is still the default.
+        # The default between web options and standard options should result in the same settings,
+        # so that we don't accidentally change something unintentionally
+        if self.options.starting_gags.value == self.options.starting_gags.default:
+            self.options.starting_gags.value = list(self.options.web_starting_gags.value) + ["randomized"] * self.options.web_random_gags.value
+        if self.options.win_condition.value == self.options.win_condition.default:
+            self.options.win_condition.value = self.convert_web_win_conditions()
+
+
         # Calculate what our starting gag tracks should be
-        startingTracks = self.calculate_starting_tracks()
+        startingTracks = self.calculate_starting_tracks(self.options.starting_gags.value)
 
         # Save as attributes so we can reference this later in fill_slot_data()
         self.startingTracks = startingTracks
+
+        #Randomize win conditions
+        if "randomized" in self.options.win_condition.value:
+            self.options.win_condition.value = self.randomize_win_condition(self.options.win_condition.value)
 
         startingOptionToAccess = {
             StartingTaskOption.option_ttc: ToontownItemName.TTC_ACCESS,
@@ -177,7 +188,7 @@ class ToontownWorld(World):
 
 
         # Force bounty placements
-        if self.options.win_condition_bounty.value:
+        if "bounties" in self.options.win_condition.value:
             total_bounties = self.options.total_bounties.value
             required_bounties = self.options.bounties_required.value
             valid_bounties = []
@@ -205,7 +216,7 @@ class ToontownWorld(World):
                 self.options.start_hints.value.add(ToontownItemName.BOUNTY.value)
 
         # only populate these locations if there's a reason to go there.
-        if self.options.checks_per_boss.value > 0 or self.options.win_condition_cog_bosses.value:
+        if self.options.checks_per_boss.value > 0 or "cog-bosses" in self.options.win_condition.value:
             self._force_item_placement(ToontownLocationName.FIGHT_VP,  ToontownItemName.VP)
             self._force_item_placement(ToontownLocationName.FIGHT_CFO,  ToontownItemName.CFO)
             self._force_item_placement(ToontownLocationName.FIGHT_CJ,  ToontownItemName.CJ)
@@ -320,7 +331,7 @@ class ToontownWorld(World):
         if start_laff > max_laff:
             self.options.max_laff.value = start_laff
             max_laff = self.options.max_laff.value
-        if self.options.win_condition_laff_o_lympics:  # Our goal is laff-o-lympics, only progressive +1 Boost items
+        if "laff-o-lympics" in self.options.win_condition.value:  # Our goal is laff-o-lympics, only progressive +1 Boost items
             # Lets make sure our goal isn't more than our max_laff
             # If it is, make our max the same as our goal
             required_laff = self.options.laff_points_required.value
@@ -540,7 +551,16 @@ class ToontownWorld(World):
             "max_gag_xp": self.options.max_global_gag_xp.value
         }
 
-    def calculate_starting_tracks(self):
+    def calculate_starting_tracks(self, starting_gags: list):
+        gag_to_item = {
+            "toonup": ToontownItemName.TOONUP_FRAME,
+            "trap": ToontownItemName.TRAP_FRAME,
+            "lure": ToontownItemName.LURE_FRAME,
+            "sound": ToontownItemName.SOUND_FRAME,
+            "throw": ToontownItemName.THROW_FRAME,
+            "squirt": ToontownItemName.SQUIRT_FRAME,
+            "drop": ToontownItemName.DROP_FRAME
+        }
         # Define lists to pull gags from so we don't give two support tracks
         OFFENSIVE: List[ToontownItemName] = [
             ToontownItemName.TRAP_FRAME,
@@ -555,71 +575,95 @@ class ToontownWorld(World):
         ]
         ALL: List[ToontownItemName] = OFFENSIVE + SUPPORT
         rng = self.multiworld.random
-        gag_to_item = {
-                "toonup": ToontownItemName.TOONUP_FRAME,
-                "trap": ToontownItemName.TRAP_FRAME,
-                "lure": ToontownItemName.LURE_FRAME,
-                "sound": ToontownItemName.SOUND_FRAME,
-                "throw": ToontownItemName.THROW_FRAME,
-                "squirt": ToontownItemName.SQUIRT_FRAME,
-                "drop": ToontownItemName.DROP_FRAME
-            }
-        
-        if "randomized" not in self.options.starting_gags:
-            starting_gags = [gag_to_item.get(gag) for gag in self.options.starting_gags.value]
-            if (not any([gag in starting_gags for gag in OFFENSIVE])
-                and self.options.treasures_per_location.value <= 1  # This is one to handle the edge case where our tpsanity is treasures
-                and (self.options.fish_checks.value == self.options.fish_checks.option_none
-                     or self.options.fish_progression.value in [
-                        self.options.fish_progression.option_licenses,
-                        self.options.fish_progression.option_licenses_and_rods
-                    ])
-            ):
-                logging.warning("Sphere 1 likely contains 0 checks, adding an offensive gag to starting gags to avoid this.")
-                if ToontownItemName.LURE_FRAME in starting_gags:
-                    starting_gags.append(rng.choice(OFFENSIVE))
+        choices = ALL.copy()
+
+        starting_random_gags = starting_gags.count("randomized")
+        starting_gag_items = [gag_to_item[item] for item in starting_gags if item in gag_to_item]
+
+        for i in starting_gag_items:
+            choices.remove(i)
+
+        for i in range(starting_random_gags):
+            if len(starting_gag_items) == 0: #first gag always should be offensive.
+                chosen = rng.choice(OFFENSIVE)
+                starting_gag_items.append(chosen)
+                choices.remove(chosen)
+
+            elif len(starting_gag_items) == 1:
+                first_track = starting_gag_items[0]
+                if first_track == ToontownItemName.TRAP_FRAME:
+                    chosen = ToontownItemName.LURE_FRAME
+                    starting_gag_items.append(chosen)
+                    choices.remove(chosen)
+                elif first_track in SUPPORT: #ensure an offensive gag if the first track was support
+                    chosen = rng.choice(OFFENSIVE)
+                    starting_gag_items.append(chosen)
+                    choices.remove(chosen)
                 else:
-                    choices = OFFENSIVE.copy()
-                    choices.remove(ToontownItemName.TRAP_FRAME)
-                    starting_gags.append(rng.choice(choices))
-            return starting_gags
-        else:
-            starting_gags = [gag_to_item.get(gag) for gag in self.options.starting_gags.value if gag != "randomized"]
-
-        if len(starting_gags) == 0:
-            # First force pick an offensive track
-            first_track = rng.choice(OFFENSIVE)
-
-            # Edge case, if we got trap then second track MUST be lure
-            if first_track == ToontownItemName.TRAP_FRAME:
-                second_track = ToontownItemName.LURE_FRAME
-                return [first_track, second_track]
-
-            # Otherwise we can choose any track that isn't the first one
-            choices = ALL.copy()
-            choices.remove(first_track)
-            second_track = rng.choice(choices)
-
-            return [first_track, second_track]
-
-        elif len(starting_gags) == 1:
-            first_track = starting_gags[0]
-            # Ensure we have an offensive gag we can use
-            if first_track == ToontownItemName.TRAP_FRAME:
-                second_track = ToontownItemName.LURE_FRAME
-
-            elif first_track == ToontownItemName.TOONUP_FRAME or ToontownItemName.LURE_FRAME:
-                choices = OFFENSIVE.copy()
-                if first_track == ToontownItemName.TOONUP_FRAME:
-                    choices.remove(ToontownItemName.TRAP_FRAME)
-                second_track = rng.choice(choices)
+                    chosen = rng.choice(choices)
+                    starting_gag_items.append(chosen)
+                    choices.remove(chosen)
 
             else:
-                choices = ALL.copy()
-                choices.remove(first_track)
-                second_track = rng.choice(choices)
-            return first_track, second_track
-        return starting_gags
+                chosen = rng.choice(choices)
+                starting_gag_items.append(chosen)
+                choices.remove(chosen)
+
+
+        ## Check to ensure sphere 1 isn't very likely to be empty.
+        if (not any([gag in starting_gag_items for gag in OFFENSIVE])
+            and self.options.treasures_per_location.value <= 1  # This is one to handle the edge case where our tpsanity is treasures
+            and (self.options.fish_checks.value == self.options.fish_checks.option_none
+                    or self.options.fish_progression.value in [
+                    self.options.fish_progression.option_licenses,
+                    self.options.fish_progression.option_licenses_and_rods
+                ])
+        ):
+            logging.warning("[{self.multiworld.player_name[self.player]}] Sphere 1 likely contains very few checks, adding an offensive gag to starting gags to avoid this.")
+            if ToontownItemName.LURE_FRAME in starting_gags:
+                starting_gag_items.append(rng.choice(OFFENSIVE))
+            else:
+                choices = OFFENSIVE.copy()
+                choices.remove(ToontownItemName.TRAP_FRAME)
+                starting_gag_items.append(rng.choice(choices))
+
+        #Update the option to use the randomized values so that it outputs to spoiler log.
+        item_to_gag = {v:k for k,v in gag_to_item.items()}
+        self.options.starting_gags.value = [item_to_gag[i] for i in starting_gag_items]
+
+        return starting_gag_items
+
+    def convert_web_win_conditions(self) -> list:
+        """
+        Convert between web specific win condition options and the actual win condition option.
+        """
+        conditions = ["randomized"] * self.options.web_win_condition_randomized.value
+        for toggled,condition in (
+        (self.options.web_win_condition_bounty.value, "bounties"),
+        (self.options.web_win_condition_cog_bosses.value, "cog-bosses"),
+        (self.options.web_win_condition_fish_species.value, "fish-species"),
+        (self.options.web_win_condition_gag_tracks.value, "gag-tracks"),
+        (self.options.web_win_condition_hood_tasks.value, "hood-tasks"),
+        (self.options.web_win_condition_laff_o_lympics.value, "laff-o-lympics"),
+        (self.options.web_win_condition_total_tasks.value, "total-tasks")
+        ):
+            if toggled:
+                conditions.append(condition)
+        return conditions
+    
+    def randomize_win_condition(self, win_conditions: list) -> list:
+        randomized = win_conditions.count("randomized")
+        choices = list(self.options.win_condition.valid_keys)
+        choices.remove("randomized") # not a valid random choice
+        result = [i for i in win_conditions if i != "randomized"]
+        rng = self.multiworld.random
+        for i in result:
+            choices.remove(i)
+        result += rng.sample(choices, k=min(randomized, len(choices)))
+        return result
+        
+
+
 
     def get_disabled_location_types(self) -> set[ToontownLocationType]:
         """
@@ -654,7 +698,7 @@ class ToontownWorld(World):
         rev_locs = BOSS_LOCATION_TYPES[::-1]
         for i in range(len(rev_locs) - cpb):
             forbidden_location_types.add(rev_locs[i])
-        wcb = self.options.win_condition_cog_bosses.value
+        wcb = "cog-bosses" in self.options.win_condition.value
         if cpb <= 0 and not wcb:
             forbidden_location_types.add(ToontownLocationType.BOSS_META)
 

--- a/apworld/toontown/__init__.py
+++ b/apworld/toontown/__init__.py
@@ -657,7 +657,7 @@ class ToontownWorld(World):
         randomized = win_conditions.count("randomized")
         choices = list(self.options.win_condition.valid_keys)
         choices.remove("randomized") # not a valid random choice
-        result = [i for i in win_conditions if i != "randomized"]
+        result = [i for i in set(win_conditions) if i != "randomized"]
         rng = self.multiworld.random
         for i in result:
             choices.remove(i)

--- a/apworld/toontown/__init__.py
+++ b/apworld/toontown/__init__.py
@@ -578,12 +578,14 @@ class ToontownWorld(World):
         choices = ALL.copy()
 
         starting_random_gags = starting_gags.count("randomized")
-        starting_gag_items = [gag_to_item[item] for item in starting_gags if item in gag_to_item]
+        starting_gag_items = [gag_to_item[item] for item in set(starting_gags) if item in gag_to_item]
 
         for i in starting_gag_items:
             choices.remove(i)
 
         for i in range(starting_random_gags):
+            if len(choices) == 0:
+                break
             if len(starting_gag_items) == 0: #first gag always should be offensive.
                 chosen = rng.choice(OFFENSIVE)
                 starting_gag_items.append(chosen)

--- a/apworld/toontown/consts.py
+++ b/apworld/toontown/consts.py
@@ -60,20 +60,15 @@ class ToontownWinCondition(IntFlag):
     def from_options(cls, options):
         """expects archipelago world options."""
         win_conditions = cls(0)
+        lookup = {
+            "cog-bosses": cls.cog_bosses,
+            "total-tasks": cls.total_tasks,
+            "hood-tasks": cls.hood_tasks,
+            "gag-tracks": cls.gag_tracks,
+            "fish-species": cls.fish_species,
+            "laff-o-lympics": cls.laff_o_lympics,
+            "bounties": cls.bounty
+        }
         for i in options.win_condition.value:
-            match i:
-                case "cog-bosses":
-                    win_conditions = win_conditions | ToontownWinCondition.cog_bosses
-                case "total-tasks":
-                    win_conditions = win_conditions | ToontownWinCondition.total_tasks
-                case "hood-tasks":
-                    win_conditions = win_conditions | ToontownWinCondition.hood_tasks
-                case "gag-tracks":
-                    win_conditions = win_conditions | ToontownWinCondition.gag_tracks
-                case "fish-species":
-                    win_conditions = win_conditions | ToontownWinCondition.fish_species
-                case "laff-o-lympics":
-                    win_conditions = win_conditions | ToontownWinCondition.laff_o_lympics
-                case "bounties":
-                    win_conditions = win_conditions | ToontownWinCondition.bounty
+            win_conditions = win_conditions | lookup.get(i, cls(0))
         return win_conditions

--- a/apworld/toontown/consts.py
+++ b/apworld/toontown/consts.py
@@ -60,18 +60,20 @@ class ToontownWinCondition(IntFlag):
     def from_options(cls, options):
         """expects archipelago world options."""
         win_conditions = cls(0)
-        if options.win_condition_cog_bosses.value:
-            win_conditions = win_conditions | ToontownWinCondition.cog_bosses
-        if options.win_condition_total_tasks.value:
-            win_conditions = win_conditions | ToontownWinCondition.total_tasks
-        if options.win_condition_hood_tasks.value:
-            win_conditions = win_conditions | ToontownWinCondition.hood_tasks
-        if options.win_condition_gag_tracks.value:
-            win_conditions = win_conditions | ToontownWinCondition.gag_tracks
-        if options.win_condition_fish_species.value:
-            win_conditions = win_conditions | ToontownWinCondition.fish_species
-        if options.win_condition_laff_o_lympics.value:
-            win_conditions = win_conditions | ToontownWinCondition.laff_o_lympics
-        if options.win_condition_bounty.value:
-            win_conditions = win_conditions | ToontownWinCondition.bounty
+        for i in options.win_condition.value:
+            match i:
+                case "cog-bosses":
+                    win_conditions = win_conditions | ToontownWinCondition.cog_bosses
+                case "total-tasks":
+                    win_conditions = win_conditions | ToontownWinCondition.total_tasks
+                case "hood-tasks":
+                    win_conditions = win_conditions | ToontownWinCondition.hood_tasks
+                case "gag-tracks":
+                    win_conditions = win_conditions | ToontownWinCondition.gag_tracks
+                case "fish-species":
+                    win_conditions = win_conditions | ToontownWinCondition.fish_species
+                case "laff-o-lympics":
+                    win_conditions = win_conditions | ToontownWinCondition.laff_o_lympics
+                case "bounties":
+                    win_conditions = win_conditions | ToontownWinCondition.bounty
         return win_conditions

--- a/apworld/toontown/options.py
+++ b/apworld/toontown/options.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from Options import PerGameCommonOptions, Range, Choice, Toggle, OptionGroup, ProgressionBalancing, Accessibility, OptionSet, StartInventoryPool, Visibility
+from Options import PerGameCommonOptions, Range, Choice, Toggle, OptionGroup, ProgressionBalancing, Accessibility, OptionList, OptionSet, StartInventoryPool, Visibility
 
 
 class TeamOption(Range):
@@ -22,11 +22,10 @@ class StartLaffOption(Range):
     default = 20
 
 
-class StartGagOption(OptionSet):
+class StartGagOption(OptionList):
     """
-    The gags to have when starting a new game.
-    ["randomized"] will ensure you have 2 tracks, at least one being a usable offensive track.
-    if you select two other tracks here, "Randomized" will do nothing
+    The gags to have when starting a new game. "randomized" will be replaced with a valid track.
+    you cannot start with gags above level 1, duplicate values other than "randomized" will be ignored.
 
     valid keys: {"randomized", "toonup", "trap", "lure", "sound", "throw", "squirt", "drop"}
     ex. ["toonup, "sound"] will start you with toonup and sound as starting tracks.
@@ -44,8 +43,35 @@ class StartGagOption(OptionSet):
         "squirt",
         "drop"
     }
-    default = {"randomized"}
-    visibility = ~Visibility.simple_ui  # Everywhere other than simple ui (web's options page)
+    default = ["randomized", "randomized"]
+    visibility = ~(Visibility.simple_ui|Visibility.complex_ui)
+
+class StartGagOptionWeb(OptionSet):
+    """
+    The gags to have when starting a new game.
+    """
+    display_name = "Starting Gags"
+    valid_keys = {
+        "toonup",
+        "trap",
+        "lure",
+        "sound",
+        "throw",
+        "squirt",
+        "drop"
+    }
+    default = []
+    visibility = Visibility.simple_ui|Visibility.complex_ui
+
+class StartGagRandomWeb(Range):
+    """
+    Randomized starting gag count, this will add to the list of starting gags above.
+    """
+    display_name = "Starting Gags"
+    range_start = 0
+    range_end = 7
+    default = 2
+    visibility = Visibility.simple_ui|Visibility.complex_ui
 
 
 class MaxLaffOption(Range):
@@ -130,10 +156,28 @@ class MaxTaskCapacityOption(Range):
     range_end = 6
     default = 4
 
-class WinConditionCogBosses(Toggle):
+class WinConditions(OptionList):
+    """Win Conditions, options are explained in the settings ending with _required"""
+    display_name = "Win Conditions"
+    valid_keys = {
+        "randomized",
+        "cog-bosses",
+        "total-tasks",
+        "hood-tasks",
+        "gag-tracks",
+        "fish-species",
+        "laff-o-lympics",
+        "bounties"
+    }
+    default = ["cog-bosses"]
+    visibility = ~(Visibility.simple_ui|Visibility.complex_ui)
+
+
+class WinConditionCogBossesWeb(Toggle):
     """Defeat a number of cog bosses to complete the game (determined by cog_bosses_required)."""
     display_name = "Cog Bosses"
     default = True
+    visibility = Visibility.simple_ui|Visibility.complex_ui
 
 class CogBossesRequired(Range):
     """
@@ -145,10 +189,11 @@ class CogBossesRequired(Range):
     range_end = 4
     default = 4
 
-class WinConditionTotalTasks(Toggle):
+class WinConditionTotalTasksWeb(Toggle):
     """Complete a total number of tasks to complete the game (determined by total_tasks_required)."""
     display_name = "Total Tasks"
     default = False
+    visibility = Visibility.simple_ui|Visibility.complex_ui
 
 class TotalTasksRequired(Range):
     """
@@ -161,10 +206,11 @@ class TotalTasksRequired(Range):
     range_end = 72
     default = 48
 
-class WinConditionHoodTasks(Toggle):
+class WinConditionHoodTasksWeb(Toggle):
     """Complete a number of tasks from each neighborhood to complete the game (determined by hood_tasks_required)."""
     display_name = "Hood Tasks"
     default = False
+    visibility = Visibility.simple_ui|Visibility.complex_ui
 
 class HoodTasksRequired(Range):
     """
@@ -177,10 +223,11 @@ class HoodTasksRequired(Range):
     range_end = 12
     default = 8
 
-class WinConditionTotalGagTracks(Toggle):
+class WinConditionTotalGagTracksWeb(Toggle):
     """Max a certain number of gag tracks to complete the game (determined by gag_tracks_required)."""
     display_name = "Gag Tracks Maxed"
     default = False
+    visibility = Visibility.simple_ui|Visibility.complex_ui
 
 class GagTracksRequired(Range):
     """
@@ -193,10 +240,11 @@ class GagTracksRequired(Range):
     range_end = 7
     default = 5
 
-class WinConditionFishSpecies(Toggle):
+class WinConditionFishSpeciesWeb(Toggle):
     """Catch a certain amount of fish species to complete the game (determined by fish_species_required)."""
     display_name = "Fish Species"
     default = False
+    visibility = Visibility.simple_ui|Visibility.complex_ui
 
 class FishSpeciesRequired(Range):
     """
@@ -209,10 +257,11 @@ class FishSpeciesRequired(Range):
     range_end = 70
     default = 70
 
-class WinConditionLaffOLympics(Toggle):
+class WinConditionLaffOLympicsWeb(Toggle):
     """Reach a certain amount of laff to complete the game (determined by laff_points_required)."""
     display_name = "Laff o lympics"
     default = False
+    visibility = Visibility.simple_ui|Visibility.complex_ui
 
 class LaffPointsRequired(Range):
     """
@@ -225,10 +274,11 @@ class LaffPointsRequired(Range):
     range_end = 150
     default = 120
 
-class WinConditionBounty(Toggle):
+class WinConditionBountyWeb(Toggle):
     """Player must reach a certain number of bounty checks to complete the game (determined by bounties_required, total_bounties)"""
     display_name = "Bounty"
     default = False
+    visibility = Visibility.simple_ui|Visibility.complex_ui
 
 class BountiesRequired(Range):
     """
@@ -257,6 +307,18 @@ class BountiesHinted(Toggle):
     """Should bounties be hinted from the beginning of the run?"""
     display_name = "Hinted Bounties"
     default = False
+
+class WinConditionRandomizedWeb(Range, Toggle):
+    """
+    How many Win Conditions will be selected for goal
+    if 0 or equal or larger than selected win condition count, all selected win conditions will be active.
+    """
+    display_name = "Randomized Win Conditions"
+    range_start = 0
+    range_end = len(WinConditions.valid_keys)
+    default = 0
+    visibility = ~(Visibility.simple_ui|Visibility.complex_ui)
+
 
 class TPSanity(Choice):
     """
@@ -650,6 +712,8 @@ class ToontownOptions(PerGameCommonOptions):
     max_laff: MaxLaffOption
     starting_laff: StartLaffOption
     starting_gags: StartGagOption
+    web_starting_gags: StartGagOptionWeb
+    web_random_gags: StartGagRandomWeb
     base_global_gag_xp: BaseGlobalGagXPRange
     max_global_gag_xp: MaxGlobalGagXPRange
     damage_multiplier: DamageMultiplierRange
@@ -657,13 +721,15 @@ class ToontownOptions(PerGameCommonOptions):
     starting_money: StartMoneyOption
     starting_task_capacity: StartingTaskCapacityOption
     max_task_capacity: MaxTaskCapacityOption
-    win_condition_cog_bosses: WinConditionCogBosses
-    win_condition_total_tasks: WinConditionTotalTasks
-    win_condition_hood_tasks: WinConditionHoodTasks
-    win_condition_gag_tracks: WinConditionTotalGagTracks
-    win_condition_fish_species: WinConditionFishSpecies
-    win_condition_laff_o_lympics: WinConditionLaffOLympics
-    win_condition_bounty: WinConditionBounty
+    win_condition: WinConditions
+    web_win_condition_cog_bosses: WinConditionCogBossesWeb
+    web_win_condition_total_tasks: WinConditionTotalTasksWeb
+    web_win_condition_hood_tasks: WinConditionHoodTasksWeb
+    web_win_condition_gag_tracks: WinConditionTotalGagTracksWeb
+    web_win_condition_fish_species: WinConditionFishSpeciesWeb
+    web_win_condition_laff_o_lympics: WinConditionLaffOLympicsWeb
+    web_win_condition_bounty: WinConditionBountyWeb
+    web_win_condition_randomized: WinConditionRandomizedWeb
     cog_bosses_required: CogBossesRequired
     total_tasks_required: TotalTasksRequired
     hood_tasks_required: HoodTasksRequired
@@ -712,18 +778,20 @@ toontown_option_groups: list[OptionGroup] = [
     ]),
     OptionGroup("Toon Settings", [
         TeamOption, MaxLaffOption, StartLaffOption, StartingTaskOption,
-        StartGagOption,BaseGlobalGagXPRange, MaxGlobalGagXPRange, 
+        StartGagOption, StartGagOptionWeb, StartGagRandomWeb,
+        BaseGlobalGagXPRange, MaxGlobalGagXPRange, 
         DamageMultiplierRange, OverflowModRange, StartMoneyOption, 
         StartingTaskCapacityOption, MaxTaskCapacityOption, DeathLinkOption
     ]),
     OptionGroup("Win Condition", [
-        WinConditionCogBosses, CogBossesRequired,
-        WinConditionTotalTasks, TotalTasksRequired,
-        WinConditionHoodTasks, HoodTasksRequired,
-        WinConditionTotalGagTracks, GagTracksRequired,
-        WinConditionFishSpecies, FishSpeciesRequired,
-        WinConditionLaffOLympics, LaffPointsRequired,
-        WinConditionBounty, BountiesRequired,
+        WinConditions, WinConditionRandomizedWeb,
+        WinConditionCogBossesWeb, CogBossesRequired,
+        WinConditionTotalTasksWeb, TotalTasksRequired,
+        WinConditionHoodTasksWeb, HoodTasksRequired,
+        WinConditionTotalGagTracksWeb, GagTracksRequired,
+        WinConditionFishSpeciesWeb, FishSpeciesRequired,
+        WinConditionLaffOLympicsWeb, LaffPointsRequired,
+        WinConditionBountyWeb, BountiesRequired,
         ], False),
     OptionGroup("Check/Item Behavior", [
         TPSanity, TreasuresPerLocation, ChecksPerBoss, GagTrainingCheckBehavior,

--- a/apworld/toontown/ruledefs.py
+++ b/apworld/toontown/ruledefs.py
@@ -152,7 +152,7 @@ def HasEnoughLaff(state: CollectionState, locentr: LocEntrDef, world: MultiWorld
         base_hp = options.starting_laff.value
         max_hp = options.max_laff.value
         goal_laff = options.laff_points_required.value
-        laff_o = options.win_condition_laff_o_lympics
+        laff_o = "laff-o-lympics" in options.win_condition
         if laff_o:
             max_hp = max(max_hp, goal_laff)
     else:
@@ -680,8 +680,8 @@ def AllFishCaught(state: CollectionState, locentr: LocEntrDef, world: MultiWorld
 @rule(Rule.TaskedAllHoods)
 def TaskedAllHoods(state: CollectionState, locentr: LocEntrDef, world: MultiWorld, player: int, options, argument: Tuple = None):
     if isinstance(options, ToontownOptions):
-        total_tasks = options.win_condition_total_tasks
-        hood_tasks = options.win_condition_hood_tasks
+        total_tasks = "total-tasks" in options.win_condition
+        hood_tasks = "hood-tasks" in options.win_condition
         tasks_required = options.total_tasks_required.value
     else:
         total_tasks = options.get("win_condition", 0) & ToontownWinCondition.total_tasks


### PR DESCRIPTION
- Additionally, convert win condition to a list, rather than separate options. this might make specific randomized conditions more difficult without using triggers.
- Updates the two above options when randomizing for the purpose of displaying to the spoiler log.


NOTE: breaking change for yamls, existing yamls will not function with this change. merge this with a version increase for clarity. (0.15)

to preserve existing yamls, changing randomized gags to have two randomized entries, and changing any win_condition_x to web_win_condition_x will have the current functionality - recommend swapping to the new win_conditions entry however for win conditions if possible.