### PR TITLE
KnockKnockDoor: Heal a toon when hearing a knock knock joke

### DIFF
--- a/astron/dclass/ttap.dc
+++ b/astron/dclass/ttap.dc
@@ -2555,6 +2555,7 @@ dclass DistributedNPCKartClerk : DistributedNPCToonBase {
 };
 
 dclass DistributedKnockKnockDoor : DistributedAnimatedProp {
+  healToon(uint32) airecv clsend;
 };
 
 dclass DistributedElevator : DistributedObject {


### PR DESCRIPTION
This pull request introduces a few changes to the `DistributedKnockKnockDoor` class and its associated AI class to add a cooldown mechanism and a healing feature for toons. The most important changes include adding new methods to manage cooldowns, modifying the interaction logic to include healing, and cleaning up unused methods.

Enhancements to `DistributedKnockKnockDoor`:

* Added a `cooldown` attribute and methods `setCooldown` and `resetCooldown` to manage cooldown periods for interactions. [[1]](diffhunk://#diff-9acec79654f1a1aec74b30669137c121dad8d4e85e0f96649e47b3990433f84eL13-R21) [[2]](diffhunk://#diff-9acec79654f1a1aec74b30669137c121dad8d4e85e0f96649e47b3990433f84eR58-R66)
* Updated the `knockKnockTrack` method to include calls to `healToon` and `setCooldown` to heal avatars and initiate cooldown after interaction.
* Introduced the `healToon` method to send an update for healing the interacting avatar.

Enhancements to `DistributedKnockKnockDoorAI`:

* Added a `cooldown` attribute and methods `setCooldown` and `resetCooldown` to manage cooldown periods for server-side interactions. [[1]](diffhunk://#diff-2fff6b5055949c85bf1659c809825c4e7ee66dce073d135de80ff0e0505db0f5L8-R30) [[2]](diffhunk://#diff-2fff6b5055949c85bf1659c809825c4e7ee66dce073d135de80ff0e0505db0f5R41-R51)
* Implemented the `healToon` method to heal avatars based on their maximum health and the zone's healing amount (from TreasureGlobals).

Cleanup:

* Removed unused methods `setAvatarInteract`, `enterOff`, `exitOff`, `exitAttract`, and `exitPlaying` from `DistributedKnockKnockDoor`. [[1]](diffhunk://#diff-9acec79654f1a1aec74b30669137c121dad8d4e85e0f96649e47b3990433f84eL49-L51) [[2]](diffhunk://#diff-9acec79654f1a1aec74b30669137c121dad8d4e85e0f96649e47b3990433f84eL116-L128)
* Removed unused methods `enterOff`, `exitOff`, and `exitAttract` from `DistributedKnockKnockDoorAI`.