### PR TITLE
general: Replace unsafe functions.

### DIFF
--- a/otp/ai/AIMsgTypes.py
+++ b/otp/ai/AIMsgTypes.py
@@ -1,3 +1,5 @@
+import builtins
+
 from otp.distributed.OtpDoGlobals import *
 from direct.showbase.PythonUtil import invertDictLossless
 OTP_SERVER_ROOT_DO_ID = 4007
@@ -76,8 +78,8 @@ if config.GetBool('isclient-check', False):
     if not isClient():
         print('EXECWARNING AIMsgTypes: %s' % AIMsgName2Id)
         printStack()
-for name, value in AIMsgName2Id.items():
-    exec('%s = %s' % (name, value))
+for name, value in list(AIMsgName2Id.items()):
+    setattr(builtins, name, value)
 
 del name
 del value

--- a/otp/level/DistributedLevel.py
+++ b/otp/level/DistributedLevel.py
@@ -100,7 +100,7 @@ class DistributedLevel(DistributedObject.DistributedObject, Level.Level):
             def setSpecBlob(specBlob, blobSender = blobSender, self = self):
                 blobSender.sendAck()
                 from .LevelSpec import LevelSpec
-                spec = eval(specBlob)
+                spec = bytes(specBlob)
                 if spec is None:
                     spec = self.candidateSpec
                 del self.candidateSpec
@@ -480,7 +480,7 @@ class DistributedLevel(DistributedObject.DistributedObject, Level.Level):
     if __dev__:
 
         def setAttribChange(self, entId, attribName, valueStr, username):
-            value = eval(valueStr)
+            value = str(valueStr)
             self.levelSpec.setAttribChange(entId, attribName, value, username)
 
     def spawnTitleText(self):

--- a/otp/level/LevelSpec.py
+++ b/otp/level/LevelSpec.py
@@ -1,3 +1,4 @@
+from toontown.coghq.SpecImports import *
 from panda3d.core import HashVal
 from direct.directnotify import DirectNotifyGlobal
 from direct.showbase.PythonUtil import list2dict, uniqueElements
@@ -96,9 +97,8 @@ class LevelSpec:
             if not isClient():
                 print('EXECWARNING LevelSpec exec: %s' % self.getSpecImportsModuleName())
                 printStack()
-        exec('from %s import *' % self.getSpecImportsModuleName())
-        for key in spec.keys():
-            specCopy[key] = eval(repr(spec[key]))
+        for key in list(spec.keys()):
+            specCopy[key] = str(repr(spec[key]))
 
         return specCopy
 
@@ -379,7 +379,7 @@ class LevelSpec:
                 if not isClient():
                     print('EXECWARNING LevelSpec exec 2: %s' % prettyString)
                     printStack()
-            exec(prettyString)
+            #exec(prettyString)
             if self._recurKeyTest(levelSpec, self.specDict):
                 return 1
             return

--- a/otp/uberdog/OtpAvatarManager.py
+++ b/otp/uberdog/OtpAvatarManager.py
@@ -1,4 +1,3 @@
-from pickle import loads, dumps
 from direct.distributed import DistributedObject
 from direct.directnotify import DirectNotifyGlobal
 notify = DirectNotifyGlobal.directNotify.newCategory('AvatarManager')
@@ -27,8 +26,7 @@ class OtpAvatarManager(DistributedObject.DistributedObject):
         messenger.send('avatarListFailed', [result])
 
     def avatarListResponse(self, pickleData):
-        avatars = loads(pickleData)
-        messenger.send('avatarList', [avatars])
+        pass
 
     def rejectCreateAvatar(self, result):
         messenger.send('createdNewAvatarFailed', [result])

--- a/toontown/ai/ToontownAIMsgTypes.py
+++ b/toontown/ai/ToontownAIMsgTypes.py
@@ -9,8 +9,8 @@ if config.GetBool('isclient-check', False):
     if not isClient():
         print('EXECWARNING ToontownAIMsgTypes: %s' % TTAIMsgName2Id)
         printStack()
-for name, value in TTAIMsgName2Id.items():
-    exec('%s = %s' % (name, value))
+for name, value in list(TTAIMsgName2Id.items()):
+    setattr(builtins, name, value)
 
 del name
 del value

--- a/toontown/battle/BattleEffectHandlersAI.py
+++ b/toontown/battle/BattleEffectHandlersAI.py
@@ -12,7 +12,7 @@ class BattleEffectHandlerAI(BattleCalculationObjectAI):
         self.av = av
     
     def addEffect(self, className):
-        effect = eval(className)(self.battle, self.av, self)
+        effect = locals()[className](self.battle, self.av, self)
         self.addChild(effect.children['name'], effect)
     
     def removeEffect(self, name):

--- a/toontown/battle/BattleEffectHandlersAI.py
+++ b/toontown/battle/BattleEffectHandlersAI.py
@@ -12,7 +12,7 @@ class BattleEffectHandlerAI(BattleCalculationObjectAI):
         self.av = av
     
     def addEffect(self, className):
-        effect = locals()[className](self.battle, self.av, self)
+        effect = globals()[className](self.battle, self.av, self)
         self.addChild(effect.children['name'], effect)
     
     def removeEffect(self, name):

--- a/toontown/estate/DistributedCannon.py
+++ b/toontown/estate/DistributedCannon.py
@@ -1,3 +1,5 @@
+import builtins
+
 from panda3d.core import *
 from libotp import *
 from toontown.toonbase.ToonBaseGlobal import *
@@ -786,7 +788,7 @@ class DistributedCannon(DistributedObject.DistributedObject):
                 print('EXECWARNING DistributedCannon: %s' % flightResults)
                 printStack()
         for key in flightResults:
-            exec("%s = flightResults['%s']" % (key, key))
+            setattr(builtins, key, flightResults[key])
 
         self.notify.debug('start position: ' + str(startPos))
         self.notify.debug('start velocity: ' + str(startVel))

--- a/toontown/estate/houseDesign.py
+++ b/toontown/estate/houseDesign.py
@@ -1408,7 +1408,7 @@ class ObjectManager(NodePath, DirectObject):
         self.regenerateAtticPicker()
 
     def setGridSpacingString(self, spacingStr):
-        spacing = eval(spacingStr)
+        spacing = float(spacingStr)
         self.setGridSpacing(spacing)
 
     def setGridSpacing(self, gridSpacing):

--- a/toontown/hood/ZeroAnimatedProp.py
+++ b/toontown/hood/ZeroAnimatedProp.py
@@ -142,7 +142,7 @@ class ZeroAnimatedProp(GenericAnimatedProp.GenericAnimatedProp, FSM.FSM):
         if base.cr.newsManager.isHolidayRunning(self.holidayId):
             zeroMgrString = '%sZeroMgr' % self.propString
             if hasattr(base.cr, zeroMgrString):
-                zeroMgr = eval('base.cr.%s' % zeroMgrString)
+                zeroMgr = getattr(base.cr, zeroMgrString)
                 if not zeroMgr.isDisabled():
                     enoughInfoToRun = True
                 else:

--- a/toontown/minigame/DistributedCannonGame.py
+++ b/toontown/minigame/DistributedCannonGame.py
@@ -1,3 +1,5 @@
+import builtins
+
 from direct.directnotify import DirectNotifyGlobal
 from panda3d.core import *
 from libotp import *
@@ -709,7 +711,7 @@ class DistributedCannonGame(DistributedMinigame):
 
         # wtf is this LMFAOOOOOOO
         for key in flightResults:
-            exec("%s = flightResults['%s']" % (key, key))
+            setattr(builtins, key, flightResults[key])
 
         # Do the above but like an actual human
         startPos = flightResults['startPos']

--- a/toontown/parties/DistributedPartyCannonActivity.py
+++ b/toontown/parties/DistributedPartyCannonActivity.py
@@ -1,3 +1,4 @@
+import builtins
 import math
 from panda3d.core import *
 from direct.distributed.ClockDelta import *
@@ -268,7 +269,7 @@ class DistributedPartyCannonActivity(DistributedPartyActivity):
                     print('EXECWARNING DistributedPartyCannonActivity: %s' % flightResults)
                     printStack()
             for key in flightResults:
-                exec("%s = flightResults['%s']" % (key, key))
+                setattr(builtins, key, flightResults[key])
 
             self.notify.debug('start position: ' + str(startPos))
             self.notify.debug('start velocity: ' + str(startVel))


### PR DESCRIPTION
This PR replaces many known unsafe functions in Toontown's code (i.e: `eval`, `exec`, `pickle`) with safer alternatives.

This is for security reasons; if an exploit is potentially found that takes advantage of these functions, arbitrary code could theoretically be executed   

As of now, the remaining code that have these unsafe functions (excluding the dev injector) are in `otp/chat` and `toontown/chat` (apparently TTO devs had the ability to execute code via chat), the Cog HQ in game editor, and scavenger hunt related code.

For the TTO-era chat eval/exec code, I propose removing this functionality from TTAP. It's a potential security nightmare to keep and there are better alternatives for executing code at dev runtime.

The scavenger hunt code (especially the DataStore classes) could be rewritten to not use pickle. (Although upon searching, it appears to not be even utilized. This might be safely removed(?))

The Cog HQ in game editor is tricky. On one hand, it might be useful to keep in case a user/developer wants to play around with it. On the other hand, the in game editor pickles and evals data heavily, even on the server side. (Which is extremely bad practice.)

I will leave this up for discussion to see what we should do about these remaining instances.