### PR TITLE
bugfix: correct visibility and class of web option

### DIFF
--- a/apworld/toontown/options.py
+++ b/apworld/toontown/options.py
@@ -328,8 +328,7 @@ class BountiesHinted(Toggle):
 
 class WinConditionRandomizedWeb(Range):
     """
-    How many Win Conditions will be selected for goal
-    if 0 or equal or larger than selected win condition count, all selected win conditions will be active.
+    How many additional random Win Conditions will be selected for goal?
     """
     display_name = "Randomized Win Conditions"
     range_start = 0

--- a/apworld/toontown/options.py
+++ b/apworld/toontown/options.py
@@ -326,7 +326,7 @@ class BountiesHinted(Toggle):
     display_name = "Hinted Bounties"
     default = False
 
-class WinConditionRandomizedWeb(Range, Toggle):
+class WinConditionRandomizedWeb(Range):
     """
     How many Win Conditions will be selected for goal
     if 0 or equal or larger than selected win condition count, all selected win conditions will be active.
@@ -335,7 +335,7 @@ class WinConditionRandomizedWeb(Range, Toggle):
     range_start = 0
     range_end = len(WinConditions.valid_keys)
     default = 0
-    visibility = ~(Visibility.simple_ui|Visibility.complex_ui)
+    visibility = Visibility.simple_ui|Visibility.complex_ui
 
 
 class TPSanity(Choice):


### PR DESCRIPTION
apworld fix: `web_win_conditions_randomized` was not visible in the web ui, and was being shown in the spoiler log and the generated template instead.