### PR TITLE
bugfix: Don't ask AP for non-existent locations

### DIFF
--- a/toontown/archipelago/apclient/archipelago_client.py
+++ b/toontown/archipelago/apclient/archipelago_client.py
@@ -77,6 +77,7 @@ class ArchipelagoClient(DirectObject):
         self.slot_name_to_slot_alias: Dict[str: str] = {}
         self.global_data_package: GlobalDataPackage = GlobalDataPackage()
         self.location_scouts_cache: LocationScoutsCache = LocationScoutsCache()
+        self.all_locations = []
 
     def has_slot_info(self, slot_id: int) -> bool:
         return slot_id in self.slot_id_to_slot_name

--- a/toontown/archipelago/apclient/archipelago_session.py
+++ b/toontown/archipelago/apclient/archipelago_session.py
@@ -128,7 +128,12 @@ class ArchipelagoSession:
 
         locationIDs = []
         for location in locations:
-            locationIDs.append(util.ap_location_name_to_id(location))
+            location_id = util.ap_location_name_to_id(location)
+            if location_id in self.client.all_locations:
+                locationIDs.append(location_id)
+            else:
+                self.avatar.d_setSystemMessage(0, f'DEBUG: {location.value} is missing, this is likely a generation bug caused by another apworld.')
+                self.avatar.d_setSystemMessage(0, 'DEBUG: Please inform your host to check the generation log for a warning.')
 
         scout_packet = LocationScoutsPacket()
         scout_packet.locations = locationIDs

--- a/toontown/archipelago/packets/clientbound/connected_packet.py
+++ b/toontown/archipelago/packets/clientbound/connected_packet.py
@@ -69,6 +69,9 @@ class ConnectedPacket(ClientBoundPacketBase):
         if 0 not in client.slot_id_to_slot_name:
             client.slot_id_to_slot_name[0] = NetworkSlot("Console", "No game", SlotType.spectator, [])
 
+        # Store this so we don't later ask archipelago about non-existent locations (likely caused by bugs in any apworld in the multiworld)
+        client.all_locations = self.missing_locations + self.checked_locations
+
         # Cache this successful connection on the ai
         slot_info = self.get_slot_info(self.slot)
         simbase.air.cacheArchipelagoConnectInformation(client.av.doId, slot_info.name, client.address)


### PR DESCRIPTION
Fixes disconnect when connecting to multiworlds where for some reason any pet shop or task location did not get an item (and therefore is not part of the multiworld) - most likely caused by bugs in other apworlds (not enough items to fill all locations)

prints a few debug messages onto screen whenever we attempt to scout one of such locations. (on connect, and again when you talk to the npcs in particular)