### PR TITLE
Settings: Prevent crash if control doesn't exist

### DIFF
--- a/toontown/settings/Settings.py
+++ b/toontown/settings/Settings.py
@@ -1,4 +1,4 @@
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, fields
 import json
 from typing import Union, Any
 from pathlib import Path
@@ -112,7 +112,9 @@ class Settings:
         return asdict(self.controls)
 
     def updateControls(self, controls: dict[str, str]) -> None:
-        self.controls = ControlSettings(**controls)
+        # Ensure that extra controls in our list dont crash (typically for going back to a previous version)
+        valid_args = {f.name: controls[f.name] for f in fields(ControlSettings) if f.name in controls}
+        self.controls = ControlSettings(**valid_args)
         self.set("controls", asdict(self.controls))
 
     def write(self) -> None:


### PR DESCRIPTION
Typically wouldn't be needed, but this would prevent a potential crash in the future if we add a new control and someone plays a previous version