### PR TITLE
Gardening: Bug fixes and tweaks

### DIFF
--- a/toontown/ai/HolidayManagerAI.py
+++ b/toontown/ai/HolidayManagerAI.py
@@ -37,7 +37,7 @@ class HolidayManagerAI:
     def startHoliday(self, holidayId, task=None):
         if holidayId not in self.currentHolidays:
             self.currentHolidays[holidayId] = True
-            self.air.newsManager.d_setHolidayIdList(self.currentHolidays.keys())
+            self.air.newsManager.d_setHolidayIdList(list(self.currentHolidays.keys()))
             if holidayId == ToontownGlobals.SILLY_SATURDAY_BINGO:
                 self.air.newsManager.d_setBingoStart()
             elif holidayId == ToontownGlobals.SILLY_SATURDAY_CIRCUIT:

--- a/toontown/estate/DistributedEstate.py
+++ b/toontown/estate/DistributedEstate.py
@@ -19,14 +19,12 @@ from direct.showbase import PythonUtil
 from toontown.hood import Place
 from . import Estate
 from . import HouseGlobals
-from toontown.estate import GardenGlobals
 from toontown.estate import DistributedFlower
 from toontown.estate import DistributedGagTree
 from toontown.estate import DistributedStatuary
 from . import GardenDropGame
 from . import GardenProgressMeter
 from toontown.estate import FlowerSellGUI
-from toontown.toontowngui import TTDialog
 
 class DistributedEstate(DistributedObject.DistributedObject):
     notify = directNotify.newCategory('DistributedEstate')
@@ -375,16 +373,6 @@ class DistributedEstate(DistributedObject.DistributedObject):
         self.acceptOnce(self.flowerGuiDoneEvent, self.__handleSaleDone)
         self.flowerGui = FlowerSellGUI.FlowerSellGUI(self.flowerGuiDoneEvent)
         self.accept('stoppedAsleep', self.__handleSaleDone)
-
-    def closedAwardDialog(self, value):
-        self.awardDialog.destroy()
-        base.cr.playGame.getPlace().detectedGardenPlotDone()
-
-    def awardedTrophy(self, avId):
-        if base.localAvatar.doId == avId:
-            base.cr.playGame.getPlace().detectedGardenPlotUse()
-            msg = TTLocalizer.GardenTrophyAwarded % (len(base.localAvatar.getFlowerCollection()), GardenGlobals.getNumberOfFlowerVarieties())
-            self.awardDialog = TTDialog.TTDialog(style=TTDialog.Acknowledge, text=msg, command=self.closedAwardDialog)
 
     def setClouds(self, clouds):
         self.clouds = clouds

--- a/toontown/estate/DistributedEstateAI.py
+++ b/toontown/estate/DistributedEstateAI.py
@@ -4,12 +4,9 @@ from direct.directnotify import DirectNotifyGlobal
 from direct.distributed.DistributedObjectAI import DistributedObjectAI
 
 from toontown.estate import CannonGlobals
-from toontown.estate import GardenGlobals
 from toontown.estate import HouseGlobals
 from toontown.estate.DistributedCannonAI import DistributedCannonAI
 from toontown.estate.DistributedTargetAI import DistributedTargetAI
-from toontown.fishing.DistributedFishingPondAI import DistributedFishingPondAI
-from toontown.safezone.DistributedFishingSpotAI import DistributedFishingSpotAI
 from toontown.safezone.EFlyingTreasurePlannerAI import EFlyingTreasurePlannerAI
 from toontown.safezone.ETreasurePlannerAI import ETreasurePlannerAI
 from toontown.toonbase import ToontownGlobals
@@ -34,11 +31,6 @@ class DistributedEstateAI(DistributedObjectAI):
         self.lawnItems = [[], [], [], [], [], []]
         self.activeToons = [0, 0, 0, 0, 0, 0]
         self.idList = []
-        self.spotPosHpr = [(49.1029, -124.805, 0.344704, 90, 0, 0),
-                           (46.5222, -134.739, 0.390713, 75, 0, 0),
-                           (41.31, -144.559, 0.375978, 45, 0, 0),
-                           (46.8254, -113.682, 0.46015, 135, 0, 0)]
-        self.pond = None
         self.treasurePlanner = None
         self.flyingTreasurePlanner = None
 
@@ -48,24 +40,6 @@ class DistributedEstateAI(DistributedObjectAI):
         # Spawn our treasures:
         self.treasurePlanner = ETreasurePlannerAI(self.zoneId)
         self.treasurePlanner.start()
-
-        # Generate our fishing pond:
-        self.pond = DistributedFishingPondAI(self.air)
-        self.pond.setArea(ToontownGlobals.MyEstate)
-        self.pond.generateWithRequired(self.zoneId)
-        self.pond.generateTargets()
-
-        # Generate our fishing spots:
-        for i in range(len(self.spotPosHpr)):
-            spot = DistributedFishingSpotAI(self.air)
-            spot.setPondDoId(self.pond.doId)
-            spot.setPosHpr(*self.spotPosHpr[i])
-            if not isinstance(spot, DistributedFishingSpotAI):
-                self.notify.warning('Failed to generate spot for pond %d!' % self.pond.doId)
-                continue
-
-            spot.generateWithRequired(self.zoneId)
-            self.pond.addSpot(spot)
 
         # Start the collision loop:
         taskMgr.add(self.__collisionLoop, self.uniqueName('collisionLoop'), sort=30)
@@ -296,24 +270,14 @@ class DistributedEstateAI(DistributedObjectAI):
 
         collection = av.flowerCollection
         earning = 0
-        newSpecies = 0
         for flower in av.flowerBasket.getFlower():
-            if collection.collectFlower(flower) == GardenGlobals.COLLECT_NEW_ENTRY:
-                newSpecies += 1
+            collection.collectFlower(flower)
 
-            earning += flower.getValue()
+            earning += flower.getValue() * 50 # modified to give 50x the value of the flower as earnings
 
         av.b_setFlowerBasket([], [])
         av.d_setFlowerCollection(*av.flowerCollection.getNetLists())
         av.addMoney(earning)
-        oldSpecies = len(collection) - newSpecies
-        dt = abs(len(collection) // 10 - oldSpecies // 10)
-        if dt:
-            self.notify.info('%d is getting a gardening trophy!' % avId)
-            # av.b_setMaxHp(maxHp)
-            # av.toonUp(maxHp)
-            self.sendUpdate('awardedTrophy', [avId])
-
         av.b_setGardenTrophies(list(range(len(collection) // 10)))
 
     def setClouds(self, clouds):
@@ -360,10 +324,6 @@ class DistributedEstateAI(DistributedObjectAI):
         if self.flyingTreasurePlanner:
             self.flyingTreasurePlanner.deleteAllTreasuresNow()
             self.flyingTreasurePlanner = None
-
-        if self.pond is not None:
-            self.pond.requestDelete()
-            self.pond = None
 
         for cannon in self.cannons[:]:
             cannon.requestDelete()

--- a/toontown/estate/DistributedFlowerAI.py
+++ b/toontown/estate/DistributedFlowerAI.py
@@ -67,7 +67,6 @@ class DistributedFlowerAI(DistributedPlantBaseAI, FlowerBase):
 
             if action == 'pick':
                 # Give rewards
-                av.b_setShovelSkill(av.getShovelSkill() + self.getValue())
                 av.addFlowerToBasket(self.getSpecies(), self.getVariety())
                 if av.slotData.get('flower_gardening', av.slotData.get('estate_integration', False)):
                     location = util.flower_to_location(self.getSpecies(), self.getVariety())

--- a/toontown/estate/DistributedGagTree.py
+++ b/toontown/estate/DistributedGagTree.py
@@ -31,6 +31,7 @@ class DistributedGagTree(DistributedPlantBase.DistributedPlantBase):
         self.signHasBeenStuck2Ground = False
         self._teaserPanel = None
         self.setName('DistributedGagTree')
+        self.fruits = None
         return
 
     def delete(self):
@@ -129,7 +130,7 @@ class DistributedGagTree(DistributedPlantBase.DistributedPlantBase):
 
     def handlePicking(self):
         messenger.send('wakeup')
-        if self.isFruiting() and self.canBeHarvested():
+        if self.isFruiting() and self.fruits and self.canBeHarvested():
             self.startInteraction()
             self.doHarvesting()
             return

--- a/toontown/estate/DistributedGardenPlotAI.py
+++ b/toontown/estate/DistributedGardenPlotAI.py
@@ -207,37 +207,15 @@ class DistributedGardenPlotAI(DistributedLawnDecorAI):
         self.__plantingAvId = av.doId
 
     def plantRandomFlower(self, usingFlowerAll=True, fullyGrown=False):
-        from toontown.toon.DistributedToonAI import DistributedToonAI
         av = self.air.doId2do.get(self.ownerDoId)
         if not av:
             return
 
-        if not isinstance(av, DistributedToonAI):
-            self.notify.warning('av is not a DistributedToonAI, but a %s' % av.__class__.__name__)
+        recipes = self.mgr.getUncollectedFlowerRecipes()
+        if not recipes:
             return
 
-        shovel, shovelSkill = av.getShovel(), av.getShovelSkill()
-        available_recipes = {}
-        for recipe_key, recipe in GardenGlobals.getAvailableRecipes(shovel, shovelSkill).items():
-            species, variety = GardenGlobals.getSpeciesVarietyGivenRecipe(recipe_key)
-            plant = GardenGlobals.PlantAttributes.get(species, {})
-            if plant.get('plantType') == GardenGlobals.FLOWER_TYPE:
-                available_recipes[recipe_key] = recipe
-
-        if not available_recipes:
-            return
-
-        discovered_flowers = av.flowerCollection
-        undiscovered_recipes = {}
-        for recipe_key, recipe in available_recipes.items():
-            species, variety = GardenGlobals.getSpeciesVarietyGivenRecipe(recipe_key)
-            if not discovered_flowers.hasFlower(species, variety):
-                undiscovered_recipes[recipe_key] = recipe
-
-        if undiscovered_recipes:
-            recipeKey = random.choice(list(undiscovered_recipes.keys()))
-        else:
-            recipeKey = random.choice(list(available_recipes.keys()))
+        recipeKey = random.choice(recipes)
 
         species, variety = GardenGlobals.getSpeciesVarietyGivenRecipe(recipeKey)
         

--- a/toontown/estate/DistributedPlantBase.py
+++ b/toontown/estate/DistributedPlantBase.py
@@ -74,7 +74,7 @@ class DistributedPlantBase(DistributedLawnDecor.DistributedLawnDecor):
         return self.growthLevel
 
     def getShovelAction(self):
-        if self.isFruiting() and not self.isWilted() and self.canBeHarvested():
+        if self.isFruiting() and getattr(self, 'fruits', True) and not self.isWilted() and self.canBeHarvested():
             return TTLocalizer.GardeningPick
         else:
             return TTLocalizer.GardeningRemove

--- a/toontown/estate/DistributedPlantBaseAI.py
+++ b/toontown/estate/DistributedPlantBaseAI.py
@@ -76,7 +76,6 @@ class DistributedPlantBaseAI(DistributedLawnDecorAI):
         if not av:
             return
 
-        av.b_setWateringCanSkill(av.getWateringCanSkill() + 1)
         self.d_setMovie(GardenGlobals.MOVIE_CLEAR)
 
     def update(self):

--- a/toontown/estate/GardenManagerAI.py
+++ b/toontown/estate/GardenManagerAI.py
@@ -189,6 +189,33 @@ class GardenAI:
             self.update()
         return True
     
+    def getUncollectedFlowerRecipes(self):
+        """Prioritize uncollected flowers, falling back to available recipes."""
+        av = self.air.doId2do.get(self.avId)
+        if not av:
+            return []
+
+        shovel, shovelSkill = av.getShovel(), av.getShovelSkill()
+        planted_flowers = {
+            (flower[0], flower[4]) for flower in self.data['flowers'] if flower[0] != -1
+        }
+        collected_or_picked_flowers = {
+            (flower.getSpecies(), flower.getVariety()) for flower in av.flowerBasket.getFlower()
+        }
+        available_recipes = []
+        uncollected_recipes = []
+        for recipe_key in GardenGlobals.getAvailableRecipes(shovel, shovelSkill):
+            species, variety = GardenGlobals.getSpeciesVarietyGivenRecipe(recipe_key)
+            plant = GardenGlobals.PlantAttributes.get(species, {})
+            if plant.get('plantType') != GardenGlobals.FLOWER_TYPE:
+                continue
+            available_recipes.append(recipe_key)
+            if (not av.flowerCollection.hasFlower(species, variety) and
+                    (species, variety) not in collected_or_picked_flowers and
+                    (species, variety) not in planted_flowers):
+                uncollected_recipes.append(recipe_key)
+        return uncollected_recipes or available_recipes
+
     def plantRandomFlower(self, flowerIndex, plot=None, ownerIndex=-1, plotId=-1):
         """Plants a random flower (prioritizing undiscovered) at the given index.
         """
@@ -200,34 +227,11 @@ class GardenAI:
         if flower_gardening and not av.getGardenStarted():
             return None
 
-        # Get the list of all possible flowers at the player's current shovel level.
-        shovel, shovelSkill = av.getShovel(), av.getShovelSkill()
-        available_recipes = {}
-        for recipe_key, recipe in GardenGlobals.getAvailableRecipes(shovel, shovelSkill).items():
-            species, variety = GardenGlobals.getSpeciesVarietyGivenRecipe(recipe_key)
-            plant = GardenGlobals.PlantAttributes.get(species, {})
-            if plant.get('plantType') == GardenGlobals.FLOWER_TYPE:
-                available_recipes[recipe_key] = recipe
-
-        if not available_recipes:
+        recipes = self.getUncollectedFlowerRecipes()
+        if not recipes:
             return None
 
-        # Get the list of flowers the player has already discovered.
-        discovered_flowers = av.flowerCollection
-
-        # Determine the set of undiscovered flowers.
-        undiscovered_recipes = {}
-        for recipe_key, recipe in available_recipes.items():
-            species, variety = GardenGlobals.getSpeciesVarietyGivenRecipe(recipe_key)
-            if not discovered_flowers.hasFlower(species, variety):
-                undiscovered_recipes[recipe_key] = recipe
-
-        # If there are undiscovered flowers, pick a random flower from that set.
-        if undiscovered_recipes:
-            recipeKey = random.choice(list(undiscovered_recipes.keys()))
-        # If all flowers have been discovered, pick a random flower from the full list of possible flowers.
-        else:
-            recipeKey = random.choice(list(available_recipes.keys()))
+        recipeKey = random.choice(recipes)
 
         species, variety = GardenGlobals.getSpeciesVarietyGivenRecipe(recipeKey)
         growthLevel = GardenGlobals.PlantAttributes[species]['growthThresholds'][2]

--- a/toontown/shtiker/GardenPage.py
+++ b/toontown/shtiker/GardenPage.py
@@ -249,16 +249,6 @@ class GardenPage(ShtikerPage.ShtikerPage):
             self.picker = FlowerPicker.FlowerPicker(self)
             self.picker.setPos(-0.555, 0, 0.1)
             self.picker.setScale(0.95)
-            self.FUDGE_FACTOR = 0.01
-            self.barLength = 1.1
-            self.shovelBar = DirectWaitBar(parent=self.picker, pos=(0.95, 0, -0.55), relief=DGG.SUNKEN, frameSize=(-0.65,
-             1.05,
-             -0.1,
-             0.1), borderWidth=(0.025, 0.025), scale=0.45, frameColor=(0.8, 0.8, 0.7, 1), barColor=(0.6, 0.4, 0.2, 1), range=self.barLength + self.FUDGE_FACTOR, value=self.barLength * 0.5 + self.FUDGE_FACTOR, text=' ' + TTLocalizer.Laff, text_scale=0.11, text_fg=(0.05, 0.14, 0.2, 1), text_align=TextNode.ALeft, text_pos=(-0.57, -0.035))
-            self.wateringCanBar = DirectWaitBar(parent=self.picker, pos=(0.95, 0, -0.75), relief=DGG.SUNKEN, frameSize=(-0.65,
-             1.05,
-             -0.1,
-             0.1), borderWidth=(0.025, 0.025), scale=0.45, frameColor=(0.8, 0.8, 0.7, 1), barColor=(0.4, 0.6, 1.0, 1), range=self.barLength + self.FUDGE_FACTOR, value=self.barLength * 0.5 + self.FUDGE_FACTOR, text=' ' + TTLocalizer.Laff, text_scale=0.11, text_fg=(0.05, 0.14, 0.2, 1), text_align=TextNode.ALeft, text_pos=(-0.57, -0.035))
 
     def unload(self):
         print('gardenPage Unloading')
@@ -282,27 +272,6 @@ class GardenPage(ShtikerPage.ShtikerPage):
     def updatePage(self):
         if hasattr(self, 'collectedTotal'):
             self.collectedTotal['text'] = TTLocalizer.GardenPageCollectedTotal % (len(base.localAvatar.flowerCollection), GardenGlobals.getNumberOfFlowerVarieties())
-        if hasattr(self, 'shovelBar'):
-            shovel = base.localAvatar.shovel
-            shovelName = TTLocalizer.ShovelNameDict[shovel]
-            curShovelSkill = base.localAvatar.shovelSkill
-            maxShovelSkill = GardenGlobals.ShovelAttributes[shovel]['skillPts']
-            if shovel == GardenGlobals.MAX_SHOVELS - 1:
-                maxShovelSkill -= 1
-            wateringCan = base.localAvatar.wateringCan
-            wateringCanName = TTLocalizer.WateringCanNameDict[wateringCan]
-            curWateringCanSkill = base.localAvatar.wateringCanSkill
-            maxWateringCanSkill = GardenGlobals.WateringCanAttributes[wateringCan]['skillPts']
-            if wateringCan == GardenGlobals.MAX_WATERING_CANS - 1:
-                maxWateringCanSkill -= 1
-            textToUse = TTLocalizer.GardenPageShovelInfo % (shovelName, curShovelSkill, maxShovelSkill)
-            self.shovelBar['text'] = textToUse
-            self.shovelBar['value'] = float(curShovelSkill) / float(maxShovelSkill) * self.barLength + self.FUDGE_FACTOR
-            textToUse = TTLocalizer.GardenPageWateringCanInfo % (wateringCanName, curWateringCanSkill, maxWateringCanSkill)
-            self.wateringCanBar['text'] = textToUse
-            self.wateringCanBar['value'] = float(curWateringCanSkill) / float(maxWateringCanSkill) * self.barLength + self.FUDGE_FACTOR
-        else:
-            print('no shovel bar')
         if self.mode == GardenPage_Collection:
             if hasattr(self, 'browser'):
                 self.browser.update()


### PR DESCRIPTION
- Fix level 1 gags not changing to remove after being picked
- Fix a bug where flowers can still randomly roll into types you've already gotten or planted
- Disable and remove gardening exp
- Remove unnecessary popups
- Disable and remove  fishing at the estate
- Increase flower jellybean earnings
- Fix a starting district error with holidayMgr